### PR TITLE
Remove volume = 1 for every new audio session

### DIFF
--- a/FlyleafLib/AudioMaster.cs
+++ b/FlyleafLib/AudioMaster.cs
@@ -116,8 +116,7 @@ namespace FlyleafLib
                 {
                     if (session != null) { session.UnRegisterEventClient(this); session.Dispose(); }
                     session = new AudioSessionControl(newSession);
-                    session.RegisterEventClient(this);
-                    session.SimpleAudioVolume.Volume = 1;
+                    session.RegisterEventClient(this);                    
                     Raise(nameof(VolumeSession));
                     Raise(nameof(MuteSession));
                 };


### PR DESCRIPTION
Fixes #54 

The line caused the volume of every new audio session for the same audio device to be set to 1 (100). 
Now the previously set volume will be kept and used and Flyleaf will no longer adjust other applications audio level.