### PR TITLE
Potential fix of a bug of incorrect initialization of Audio on some processors or devices

### DIFF
--- a/FlyleafLib/MediaPlayer/Audio.cs
+++ b/FlyleafLib/MediaPlayer/Audio.cs
@@ -220,7 +220,7 @@ namespace FlyleafLib.MediaPlayer
 
                 Dispose();
 
-                xaudio2         = XAudio2Create();
+                xaudio2         = XAudio2Create(ProcessorSpecifier.AnyProcessor);
                 masteringVoice  = xaudio2.CreateMasteringVoice(0, 0, AudioStreamCategory.GameEffects, _Device == Master.AudioMaster.DefaultDeviceName ? null : Master.AudioMaster.GetDeviceId(_Device));
                 sourceVoice     = xaudio2.CreateSourceVoice(waveFormat, true);
                 sourceVoice.SetSourceSampleRate(SampleRate);


### PR DESCRIPTION
Potential fix of a bug of incorrect initialization of Audio on some processors or devices who appeared after version 3.4.2 (after changing NAudio to XAudio)??

Visual Studio Errors:
`SharpGen.Runtime.SharpGenException
  HResult=0x88960001
  Message=HRESULT: [0x88960001]
  Source=SharpGen.Runtime
  StackTrace:
   at SharpGen.Runtime.Result.ThrowFailureException()
   at SharpGen.Runtime.Result.CheckError()
   at Vortice.XAudio2.XAudio2Native.XAudio2Create(Int32 flags, ProcessorSpecifier processorSpecifier)
   at Vortice.XAudio2.IXAudio2..ctor(ProcessorSpecifier processorSpecifier, Boolean registerCallback)
   at Vortice.XAudio2.XAudio2.XAudio2Create(ProcessorSpecifier processorSpecifier, Boolean registerCallback)
   at FlyleafLib.MediaPlayer.Audio.Initialize(Int32 sampleRate) in C:\Flyleaf-3.4.4\Flyleaf-3.4.4\FlyleafLib\MediaPlayer\Audio.cs:line 223
   at FlyleafLib.MediaPlayer.Audio..ctor(Player player) in C:\Flyleaf-3.4.4\Flyleaf-3.4.4\FlyleafLib\MediaPlayer\Audio.cs:line 200
   at FlyleafLib.MediaPlayer.Player..ctor(Config config) in C:\Flyleaf-3.4.4\Flyleaf-3.4.4\FlyleafLib\MediaPlayer\Player.cs:line 410
   at FlyleafPlayer.MainWindow..ctor() in C:\Flyleaf-3.4.4\Flyleaf-3.4.4\Samples\FlyleafPlayer (WPF Control) (WPF)\MainWindow.xaml.cs:line 56
   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)`

Errors in Event Logs:
`Description: The process was terminated due to an unhandled exception.
Exception Info: System.Windows.Markup.XamlParseException: The invocation of the constructor on type 'FlyleafPlayer.MainWindow' that matches the specified binding constraints threw an exception.
 ---> SharpGen.Runtime.SharpGenException: HRESULT: [0x88960001]
   at SharpGen.Runtime.Result.ThrowFailureException()
   at SharpGen.Runtime.Result.CheckError()
   at Vortice.XAudio2.XAudio2Native.XAudio2Create(Int32 flags, ProcessorSpecifier processorSpecifier)
   at Vortice.XAudio2.IXAudio2..ctor(ProcessorSpecifier processorSpecifier, Boolean registerCallback)
   at Vortice.XAudio2.XAudio2.XAudio2Create(ProcessorSpecifier processorSpecifier, Boolean registerCallback)
   at FlyleafLib.MediaPlayer.Audio.Initialize(Int32 sampleRate)
   at FlyleafLib.MediaPlayer.Audio..ctor(Player player)
   at FlyleafLib.MediaPlayer.Player..ctor(Config config)
   at FlyleafPlayer.MainWindow..ctor()
   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)
   --- End of inner exception stack trace ---
   at System.Windows.Markup.XamlReader.RewrapException(Exception e, IXamlLineInfo lineInfo, Uri baseUri)
   at System.Windows.Markup.WpfXamlLoader.Load(XamlReader xamlReader, IXamlObjectWriterFactory writerFactory, Boolean skipJournaledProperties, Object rootObject, XamlObjectWriterSettings settings, Uri baseUri)
   at System.Windows.Markup.WpfXamlLoader.LoadBaml(XamlReader xamlReader, Boolean skipJournaledProperties, Object rootObject, XamlAccessLevel accessLevel, Uri baseUri)
   at System.Windows.Markup.XamlReader.LoadBaml(Stream stream, ParserContext parserContext, Object parent, Boolean closeStream)
   at System.Windows.Application.LoadBamlStreamWithSyncInfo(Stream stream, ParserContext pc)
   at System.Windows.Application.LoadComponent(Uri resourceLocator, Boolean bSkipJournaledProperties)
   at System.Windows.Application.DoStartup()
   at System.Windows.Application.<.ctor>b__1_0(Object unused)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
   at System.Windows.Threading.DispatcherOperation.InvokeImpl()
   at System.Windows.Threading.DispatcherOperation.InvokeInSecurityContext(Object state)
   at MS.Internal.CulturePreservingExecutionContext.CallbackWrapper(Object obj)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at MS.Internal.CulturePreservingExecutionContext.Run(CulturePreservingExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Windows.Threading.DispatcherOperation.Invoke()
   at System.Windows.Threading.Dispatcher.ProcessQueue()
   at System.Windows.Threading.Dispatcher.WndProcHook(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
   at System.Windows.Threading.Dispatcher.LegacyInvokeImpl(DispatcherPriority priority, TimeSpan timeout, Delegate method, Object args, Int32 numArgs)
   at MS.Win32.HwndSubclass.SubclassWndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam)
   at MS.Win32.UnsafeNativeMethods.DispatchMessage(MSG& msg)
   at System.Windows.Threading.Dispatcher.PushFrameImpl(DispatcherFrame frame)
   at System.Windows.Threading.Dispatcher.PushFrame(DispatcherFrame frame)
   at System.Windows.Threading.Dispatcher.Run()
   at System.Windows.Application.RunDispatcher(Object ignore)
   at System.Windows.Application.RunInternal(Window window)
   at System.Windows.Application.Run()
   at FlyleafPlayer.App.Main()`