### PR TITLE
Restore from minimize

### DIFF
--- a/FlyleafLib/Utils/ZOrderHandler.cs
+++ b/FlyleafLib/Utils/ZOrderHandler.cs
@@ -131,7 +131,7 @@ namespace FlyleafLib
                         Application.Current.Dispatcher.Invoke(() =>
                         {
                             for (int i=0; i<SavedZOrder.Count; i++)
-                                if (WindowNamesWindows.TryGetValue(SavedZOrder[i].window, out Window window))
+                                if (WindowNamesWindows.TryGetValue(SavedZOrder[i].window, out Window window) && window.ShowActivated == false)
                                     window.Activate();
 
                             Debug.WriteLine("Restored");


### PR DESCRIPTION
When restore from minimize, the window is required to show before active.
"Cannot call DragMove or Activate before a Window is shown."
![Screenshot 2022-12-05 171106](https://user-images.githubusercontent.com/37483861/205586967-23c34827-1d7b-44b2-887d-4e15296e8861.png)
