### PR TITLE
Set WS_CHILD to Overlay and Surface windows

### DIFF
--- a/FlyleafLib/Controls/WPF/FlyleafHost.cs
+++ b/FlyleafLib/Controls/WPF/FlyleafHost.cs
@@ -631,10 +631,10 @@ namespace FlyleafLib.Controls.WPF
             OwnerHandle = new WindowInteropHelper(Owner).EnsureHandle();
             matrix = PresentationSource.FromVisual(Owner).CompositionTarget.TransformFromDevice;
             HostDataContext = DataContext;
-            Owner.LocationChanged += Owner_LocationChanged;
+            //Owner.LocationChanged += Owner_LocationChanged;
 
             ZOrderHandler.Register(Owner);
-
+            
             if (IsVisible)
             {
                 Surface.Show();
@@ -693,12 +693,12 @@ namespace FlyleafLib.Controls.WPF
             if (!IsVisible || !IsAttached || IsFullScreen || IsResizing)
                 return;
 
-            Rect rectInit = new Rect(matrix.Transform(PointToScreen(zeroPoint)), RenderSize);
+            Rect rectInit = new Rect(TranslatePoint(zeroPoint, Owner), RenderSize);
             Rect rectIntersect = rectInit;
 
             FrameworkElement parent = this;
             while ((parent = VisualTreeHelper.GetParent(parent) as FrameworkElement) != null)
-                rectIntersect.Intersect(new Rect(matrix.Transform(parent.PointToScreen(zeroPoint)), parent.RenderSize));
+                rectIntersect.Intersect(new Rect(TranslatePoint(zeroPoint, Owner), parent.RenderSize));
 
             if (rectInit != rectInitLast)
             {
@@ -1045,17 +1045,17 @@ namespace FlyleafLib.Controls.WPF
             // Resize (MouseDown + ResizeSide != 0)
             else if (IsResizing)
             {
-                Point x1 = new Point(Overlay.Left, Overlay.Top);
+                Point x1 = new Point(Surface.Left, Surface.Top);
 
-                Resize(Overlay, OverlayHandle, cur, ResizingSide, CurResizeRatio);
+                Resize(Surface, SurfaceHandle, cur, ResizingSide, CurResizeRatio);
 
                 if (IsAttached)
                 {
-                    Point x2 = new Point(Overlay.Left, Overlay.Top);
+                    Point x2 = new Point(Surface.Left, Surface.Top);
                     
                     MarginTarget.Margin = new Thickness(MarginTarget.Margin.Left + x2.X - x1.X, MarginTarget.Margin.Top + x2.Y - x1.Y, MarginTarget.Margin.Right, MarginTarget.Margin.Bottom);
-                    Width = Overlay.Width;
-                    Height = Overlay.Height;
+                    Width = Surface.Width;
+                    Height = Surface.Height;
                 }
             }
 
@@ -1094,8 +1094,8 @@ namespace FlyleafLib.Controls.WPF
                 {
                     if (DetachedDragMove == AvailableWindows.Overlay || DetachedDragMove == AvailableWindows.Both)
                     {
-                        Overlay.Left  += cur.X - mouseLeftDownPoint.X;
-                        Overlay.Top   += cur.Y - mouseLeftDownPoint.Y;
+                        Surface.Left  += cur.X - mouseLeftDownPoint.X;
+                        Surface.Top   += cur.Y - mouseLeftDownPoint.Y;
                     }
                 }
             }
@@ -1451,6 +1451,10 @@ namespace FlyleafLib.Controls.WPF
             Overlay.ShowInTaskbar = false;
             Surface.Topmost = wasTopmost;
 
+            SetWindowLong(OverlayHandle, (int)WindowLongFlags.GWL_STYLE, (IntPtr)(WindowStyles.WS_CHILD | WindowStyles.WS_VISIBLE));
+            SetParent(OverlayHandle, SurfaceHandle);
+            SetWindowPos(OverlayHandle, IntPtr.Zero, 0, 0, 0, 0, (UInt32)(SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_NOACTIVATE));
+            
             if (IsStandAlone)
             {
                 Surface.Width   = Overlay.Width;
@@ -1470,9 +1474,9 @@ namespace FlyleafLib.Controls.WPF
             Overlay.SetBinding(Window.MaxHeightProperty,    new Binding(nameof(Surface.MaxHeight))  { Source = Surface, Mode = System.Windows.Data.BindingMode.TwoWay });
             Overlay.SetBinding(Window.WidthProperty,        new Binding(nameof(Surface.Width))      { Source = Surface, Mode = System.Windows.Data.BindingMode.TwoWay });
             Overlay.SetBinding(Window.HeightProperty,       new Binding(nameof(Surface.Height))     { Source = Surface, Mode = System.Windows.Data.BindingMode.TwoWay });
-            Overlay.SetBinding(Window.LeftProperty,         new Binding(nameof(Surface.Left))       { Source = Surface, Mode = System.Windows.Data.BindingMode.TwoWay });
-            Overlay.SetBinding(Window.TopProperty,          new Binding(nameof(Surface.Top))        { Source = Surface, Mode = System.Windows.Data.BindingMode.TwoWay });
-
+            //Overlay.SetBinding(Window.LeftProperty,         new Binding(nameof(Surface.Left))       { Source = Surface, Mode = System.Windows.Data.BindingMode.TwoWay });
+            //Overlay.SetBinding(Window.TopProperty,          new Binding(nameof(Surface.Top))        { Source = Surface, Mode = System.Windows.Data.BindingMode.TwoWay });
+            
             Overlay.KeyUp       += Overlay_KeyUp;
             Overlay.KeyDown     += Overlay_KeyDown;
             Overlay.Closed      += Overlay_Closed;
@@ -1568,6 +1572,9 @@ namespace FlyleafLib.Controls.WPF
             if (DetachedTopMost)
                 Surface.Topmost = false;
 
+            SetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE, (IntPtr)(WindowStyles.WS_CHILD | WindowStyles.WS_VISIBLE));
+            SetParent(SurfaceHandle, OwnerHandle);
+
             Surface.MinWidth = MinWidth;
             Surface.MinHeight = MinHeight;
 
@@ -1655,6 +1662,9 @@ namespace FlyleafLib.Controls.WPF
             }
             Rect final = new Rect(newPos.X, newPos.Y, newSize.Width, newSize.Height);
 
+            SetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE, (IntPtr)(WindowStyles.WS_BORDER | WindowStyles.WS_VISIBLE));
+            SetParent(SurfaceHandle, IntPtr.Zero);
+
             SetRect(final);
             ReSetVisibleRect();
 
@@ -1678,7 +1688,12 @@ namespace FlyleafLib.Controls.WPF
             if (IsFullScreen)
             {
                 if (IsAttached)
+                {
+                    SetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE, (IntPtr)(WindowStyles.WS_BORDER | WindowStyles.WS_VISIBLE));
+                    SetParent(SurfaceHandle, IntPtr.Zero);
+                    
                     ReSetVisibleRect();
+                }
                 else
                 {
                     beforeFullScreenPos = new Point(Surface.Left, Surface.Top);
@@ -1708,6 +1723,9 @@ namespace FlyleafLib.Controls.WPF
 
                 if (IsAttached)
                 {
+                    SetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE, (IntPtr)(WindowStyles.WS_CHILD | WindowStyles.WS_VISIBLE));
+                    SetParent(SurfaceHandle, OwnerHandle);
+                    
                     rectInitLast = rectIntersectLast = Rect.Empty;
                     Host_LayoutUpdated(null, null);
                 }
@@ -1741,7 +1759,7 @@ namespace FlyleafLib.Controls.WPF
             SetWindowRgn(SurfaceHandle, CreateRectRgn((int)(rect.X * DpiX), (int)(rect.Y * DpiY), (int)(rect.Right * DpiX), (int)(rect.Bottom * DpiY)), true);
 
             if (OverlayHandle != IntPtr.Zero)
-                SetWindowRgn(OverlayHandle, CreateRectRgn((int)(rect.X * DpiX), (int)(rect.Y * DpiY), (int)(rect.Right * DpiX), (int)(rect.Bottom * DpiY)), true);
+                SetWindowRgn(OverlayHandle, CreateRectRgn(0, 0, (int)(rect.Width * DpiX), (int)(rect.Height * DpiY)), true);
         }
 
         /// <summary>

--- a/FlyleafLib/Utils/NativeMethods.cs
+++ b/FlyleafLib/Utils/NativeMethods.cs
@@ -93,6 +93,9 @@ namespace FlyleafLib
             [DllImport("user32.dll")]
             public static extern bool GetWindowInfo(IntPtr hwnd, ref WINDOWINFO pwi);
 
+            [DllImport("user32.dll", SetLastError = true)]
+            public static extern void SetParent(IntPtr hWndChild, IntPtr hWndNewParent);
+
             [StructLayout(LayoutKind.Sequential)]
             public struct WINDOWINFO
             {
@@ -154,6 +157,14 @@ namespace FlyleafLib
                  DWLP_USER = 0x8,
                  DWLP_MSGRESULT = 0x0,
                  DWLP_DLGPROC = 0x4
+            }
+
+            [Flags]
+            public enum WindowStyles : int
+            {
+                WS_BORDER = 0x800000,
+                WS_CHILD = 0x40000000,
+                WS_VISIBLE = 0x10000000,
             }
 
             public delegate IntPtr WndProcDelegate(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);


### PR DESCRIPTION
This has various benefits:
* Overlay is positioned relative to Surface window automatically, you just need to set its position to (0,0)
* Surface is positioned relative to Owner window, you just need to find Left and Top locations of FlyleafHost.
* Should fix the weird bug you commented in the code:
> Overlay maximized on Screen 2 when Surface maximized on Screen 1
* User is not able to move these child windows using shortcut keys, without moving the parent window. They'll be recognized as controls instead of independent windows.
![image](https://user-images.githubusercontent.com/21140798/227132063-213715fe-a903-4e80-9c12-8cea99651241.png)
* You don't need to handle minimized window state manually anymore.

The only problem is the previous code was assuming that it needs to position the Overlay and Surface relative to screen, not their parent windows. I tried to change this every where I could but I'm not sure if is this getting handled any where else.
It would introduce bugs like this if it's not handled appropriately:
![image](https://user-images.githubusercontent.com/21140798/227132779-16aade9f-d318-46d8-a541-12aa06094fa0.png)
