### PR TITLE
DirectShow usb webcam improvements.

### DIFF
--- a/FlyleafLib.Controls.WPF/Resources/PopUpMenu.xaml
+++ b/FlyleafLib.Controls.WPF/Resources/PopUpMenu.xaml
@@ -3,7 +3,8 @@
                     
                     xmlns:collections="clr-namespace:System.Collections;assembly=mscorlib"
                     xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-                    >
+                    xmlns:videoDeviceEnumerator="clr-namespace:FlyleafLib.VideoDeviceEnumerator;assembly=FlyleafLib"
+                    xmlns:flyleafLib="clr-namespace:FlyleafLib;assembly=FlyleafLib">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/FlyleafLib.Controls.WPF;component/Resources/MaterialDesign.xaml"/>
@@ -635,9 +636,37 @@
         </MenuItem>
     </collections:ArrayList>
 
+    <HierarchicalDataTemplate x:Key="VideoDeviceMenuHierarchyTemplate"
+                              DataType="{x:Type videoDeviceEnumerator:IVideoDevice}" ItemsSource="{Binding Formats}">
+        <TextBlock Text="{Binding FriendlyName}">
+            <TextBlock.InputBindings>
+                <MouseBinding
+                    Command="{Binding DataContext.Player.Commands.Open, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ContextMenu}}}"
+                    CommandParameter="{Binding DefaultVideoFormatUri }"
+                    MouseAction="LeftClick" />
+            </TextBlock.InputBindings>
+        </TextBlock>
+        <HierarchicalDataTemplate.ItemTemplate>
+            <DataTemplate DataType="{x:Type videoDeviceEnumerator:IVideoFormat}">
+                <TextBlock Text="{Binding }" >
+                    <TextBlock.InputBindings>
+                        <MouseBinding
+                            Command="{Binding DataContext.Player.Commands.Open, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ContextMenu}}}"
+                            CommandParameter="{Binding Uri }"
+                            MouseAction="LeftClick" />
+                    </TextBlock.InputBindings>
+                </TextBlock>
+            </DataTemplate>
+        </HierarchicalDataTemplate.ItemTemplate>
+    </HierarchicalDataTemplate>
+
     <ContextMenu x:Key="PopUpMenu" Style="{StaticResource FlyleafContextMenu}">
-        <MenuItem Header="Open File" Command="{Binding OpenFileDialog}" Icon="{materialDesign:PackIcon FolderOutline}"/>
-        <MenuItem Header="Paste Url" Command="{Binding Player.Commands.OpenFromClipboard}" IsEnabled="{Binding CanPaste}" Icon="{materialDesign:PackIcon ContentPaste}"/>
+        <MenuItem Header="Open File" Command="{Binding OpenFileDialog}" Icon="{materialDesign:PackIcon FolderOutline}" />
+        <MenuItem Header="Paste Url" Command="{Binding Player.Commands.OpenFromClipboard}"
+                  IsEnabled="{Binding CanPaste}" Icon="{materialDesign:PackIcon ContentPaste}" />
+        <MenuItem Header="Open Device" Icon="{materialDesign:PackIcon VideoOutline}" IsEnabled="{Binding VideoDevices.Count, Source={x:Static flyleafLib:Engine.Video}}"
+                  ItemsSource="{Binding VideoDevices, Source={x:Static flyleafLib:Engine.Video}}"
+                  ItemTemplate="{StaticResource VideoDeviceMenuHierarchyTemplate}" />
         <Separator />
 
         <MenuItem ItemsSource="{Binding Player.Playlist.Items}" Icon="{materialDesign:PackIcon ViewList}">

--- a/FlyleafLib.Controls.WPF/Resources/PopUpMenu.xaml
+++ b/FlyleafLib.Controls.WPF/Resources/PopUpMenu.xaml
@@ -664,8 +664,8 @@
         <MenuItem Header="Open File" Command="{Binding OpenFileDialog}" Icon="{materialDesign:PackIcon FolderOutline}" />
         <MenuItem Header="Paste Url" Command="{Binding Player.Commands.OpenFromClipboard}"
                   IsEnabled="{Binding CanPaste}" Icon="{materialDesign:PackIcon ContentPaste}" />
-        <MenuItem Header="Open Device" Icon="{materialDesign:PackIcon VideoOutline}" IsEnabled="{Binding VideoDevices.Count, Source={x:Static flyleafLib:Engine.Video}}"
-                  ItemsSource="{Binding VideoDevices, Source={x:Static flyleafLib:Engine.Video}}"
+        <MenuItem Header="Open Device" Icon="{materialDesign:PackIcon VideoOutline}" IsEnabled="{Binding CapDevices.Count, Source={x:Static flyleafLib:Engine.Video}}"
+                  ItemsSource="{Binding CapDevices, Source={x:Static flyleafLib:Engine.Video}}"
                   ItemTemplate="{StaticResource VideoDeviceMenuHierarchyTemplate}" />
         <Separator />
 

--- a/FlyleafLib/Engine/Engine.Video.cs
+++ b/FlyleafLib/Engine/Engine.Video.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-
+using FlyleafLib.VideoDeviceEnumerator;
 using Vortice.DXGI;
 
 namespace FlyleafLib
@@ -9,10 +9,15 @@ namespace FlyleafLib
     public class VideoEngine
     {
         /// <summary>
+        /// Enumerator of Video Capture Devices
+        /// </summary>
+        private readonly VideoDeviceEnumerator.VideoDeviceEnumerator _videoDeviceEnumerator;
+
+        /// <summary>
         /// List of Video Capture Devices
         /// </summary>
-        public ObservableCollection<string>
-                                CapDevices  { get; private set; } = new ObservableCollection<string>();
+        public ObservableCollection<IVideoDevice>
+            VideoDevices => _videoDeviceEnumerator?.VideoDevices;
 
         /// <summary>
         /// List of GPU Adpaters <see cref="Config.VideoConfig.GPUAdapter"/>
@@ -26,7 +31,6 @@ namespace FlyleafLib
         public List<GPUOutput>  Screens     { get; private set; } = new List<GPUOutput>();
 
         internal IDXGIFactory2 Factory;
-        internal object lockCapDevices = new();
 
         internal VideoEngine()
         {
@@ -34,6 +38,11 @@ namespace FlyleafLib
                 throw new InvalidOperationException("Cannot create IDXGIFactory1");
 
             GPUAdapters = GetAdapters();
+
+            if (Engine.Config.FFmpegDevices)
+            {
+                _videoDeviceEnumerator = new VideoDeviceEnumerator.VideoDeviceEnumerator();
+            }
         }
 
         private Dictionary<long, GPUAdapter> GetAdapters()

--- a/FlyleafLib/Engine/Engine.Video.cs
+++ b/FlyleafLib/Engine/Engine.Video.cs
@@ -17,7 +17,7 @@ namespace FlyleafLib
         /// List of Video Capture Devices
         /// </summary>
         public ObservableCollection<IVideoDevice>
-            VideoDevices => _videoDeviceEnumerator?.VideoDevices;
+            CapDevices => _videoDeviceEnumerator?.VideoDevices;
 
         /// <summary>
         /// List of GPU Adpaters <see cref="Config.VideoConfig.GPUAdapter"/>

--- a/FlyleafLib/Engine/Engine.cs
+++ b/FlyleafLib/Engine/Engine.cs
@@ -157,9 +157,6 @@ namespace FlyleafLib
             Plugins = new PluginsEngine();
             Players = new List<Player>();
 
-            if (Config.FFmpegDevices)
-                EnumerateCapDevices();
-
             Renderer.Start();
 
             IsLoaded = true;
@@ -168,62 +165,6 @@ namespace FlyleafLib
             if (Config.UIRefresh)
                 StartThread();
         }
-
-        private unsafe static void EnumerateCapDevices()
-        {
-            try
-            {
-                string dump = null; int i = 1;
-
-                IMFAttributes capAttrs = MediaFactory.MFCreateAttributes(1);
-                IMFActivateCollection capDevices;
-
-                capAttrs.Set(CaptureDeviceAttributeKeys.SourceType, CaptureDeviceAttributeKeys.SourceTypeAudcap);
-                capDevices = MediaFactory.MFEnumDeviceSources(capAttrs);
-                
-                lock (Audio.lockCapDevices)
-                {
-                    foreach (IMFActivate capDevice in capDevices)
-                    {
-                        if (i == 1) dump = "Audio Cap Devices\r\n";
-                        dump += $"[#{i}] {capDevice.FriendlyName}\r\n";
-                        Audio.CapDevices.Add(capDevice.FriendlyName);
-                        i++;
-                    }
-                }
-
-                if (dump != null)
-                    Log.Debug(dump);
-
-                capDevices.Dispose();
-
-                dump = null; i = 1;
-                capAttrs.Set(CaptureDeviceAttributeKeys.SourceType, CaptureDeviceAttributeKeys.SourceTypeVidcap);
-                capDevices = MediaFactory.MFEnumDeviceSources(capAttrs);
-
-                lock (Video.lockCapDevices)
-                {
-                    foreach (IMFActivate capDevice in capDevices)
-                    {
-                        if (i == 1) dump = "Video Cap Devices\r\n";
-                        dump += $"[#{i}] {capDevice.FriendlyName}\r\n";
-                        Video.CapDevices.Add(capDevice.FriendlyName);
-                        i++;
-                    }
-                }
-
-                if (dump != null)
-                    Log.Debug(dump);
-
-                capAttrs.Dispose();
-                capDevices.Dispose();
-
-            } catch (Exception e)
-            {
-                Log.Error($"Failed to enumerate capture devices ({e.Message})");
-            }
-        }
-
         internal static void AddPlayer(Player player)
         {
             lock (Players)

--- a/FlyleafLib/Engine/VideoDeviceEnumerator/IVideoDevice.cs
+++ b/FlyleafLib/Engine/VideoDeviceEnumerator/IVideoDevice.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace FlyleafLib.VideoDeviceEnumerator;
+
+public interface IVideoDevice
+{
+    string FriendlyName { get; set; }
+    string SymbolicLink { get; }
+    Guid SourceType { get; set; }
+    IEnumerable<IVideoFormat> Formats { get; set; }
+    string DefaultVideoFormatUri { get; }
+    string DefaultSnapshotFormatUri { get; }
+    string ToString();
+}

--- a/FlyleafLib/Engine/VideoDeviceEnumerator/IVideoFormat.cs
+++ b/FlyleafLib/Engine/VideoDeviceEnumerator/IVideoFormat.cs
@@ -1,0 +1,13 @@
+﻿namespace FlyleafLib.VideoDeviceEnumerator;
+
+public interface IVideoFormat
+{
+    string DeviceFriendlyName { get; }
+    string MajorType { get; }
+    string SubType { get; }
+    int FrameSizeWidth { get; }
+    int FrameSizeHeight { get; }
+    int FrameRate { get; }
+    string Uri { get; }
+    string ToString();
+}

--- a/FlyleafLib/Engine/VideoDeviceEnumerator/VideoDevice.cs
+++ b/FlyleafLib/Engine/VideoDeviceEnumerator/VideoDevice.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FlyleafLib.VideoDeviceEnumerator;
+
+public class VideoDevice : IVideoDevice
+{
+    protected VideoDevice(string friendlyName, string symbolicLink, IEnumerable<IVideoFormat> formats)
+    {
+        FriendlyName = friendlyName;
+        SymbolicLink = symbolicLink;
+        Formats = formats;
+    }
+
+    public VideoDevice(string friendlyName, string symbolicLink) : this(
+        friendlyName, symbolicLink,
+        VideoFormatsViaMediaSource.GetVideoFormatsForVideoDevice(friendlyName, symbolicLink))
+    {
+    }
+
+    private IVideoFormat DefaultVideoFormat => Formats.Where(f => f.SubType.Contains("MJPG") && f.FrameRate >= 30)
+        .OrderByDescending(f => f.FrameSizeHeight).FirstOrDefault();
+
+    private IVideoFormat DefaultSnapshotFormat =>
+        Formats.Where(f => f.SubType.Contains("YUY")).OrderByDescending(f => f.FrameSizeHeight)
+            .FirstOrDefault();
+
+    public string FriendlyName { get; set; }
+    public string SymbolicLink { get; }
+    public Guid SourceType { get; set; }
+    public IEnumerable<IVideoFormat> Formats { get; set; }
+
+    public string DefaultVideoFormatUri => DefaultVideoFormat?.Uri;
+
+    public string DefaultSnapshotFormatUri => DefaultSnapshotFormat?.Uri;
+
+    public override string ToString()
+    {
+        return FriendlyName;
+    }
+}

--- a/FlyleafLib/Engine/VideoDeviceEnumerator/VideoDeviceEnumerator.cs
+++ b/FlyleafLib/Engine/VideoDeviceEnumerator/VideoDeviceEnumerator.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Management;
+using System.Windows.Data;
+using SharpGen.Runtime;
+using Vortice.MediaFoundation;
+
+namespace FlyleafLib.VideoDeviceEnumerator;
+
+public class VideoDeviceEnumerator : IDisposable
+{
+    public const string Namespace = @"root\cimv2";
+
+    public const string QueryExpression =
+        "SELECT * FROM __InstanceOperationEvent WITHIN 1 WHERE TargetInstance ISA 'Win32_PnPEntity' AND TargetInstance.Description LIKE '%USB Video Device%'";
+
+    private static readonly Guid KsCategoryVideoCamera =
+        new(0xe5323777, 0xf976, 0x4f5b, 0x9b, 0x55, 0xb9, 0x46, 0x99, 0xc4, 0x6e, 0x44);
+
+    private readonly object _lock = new();
+
+    private readonly ManagementEventWatcher _usbWatcher;
+
+    public VideoDeviceEnumerator()
+    {
+        BindingOperations.EnableCollectionSynchronization(VideoDevices, _lock);
+        EnumerateVideoDevices();
+
+        var creationQuery =
+            new WqlEventQuery(
+                QueryExpression);
+
+        var scope = new ManagementScope(Namespace);
+
+        _usbWatcher = new ManagementEventWatcher(scope, creationQuery);
+
+        _usbWatcher.EventArrived += OnUsbCameraEvent;
+
+        _usbWatcher.Start();
+    }
+
+    public ObservableCollection<IVideoDevice> VideoDevices { get; } = new();
+
+    public void Dispose()
+    {
+        _usbWatcher.EventArrived -= OnUsbCameraEvent;
+        _usbWatcher?.Stop();
+        _usbWatcher?.Dispose();
+    }
+
+    private void OnUsbCameraEvent(object sender, EventArrivedEventArgs e)
+    {
+        switch (e.NewEvent.ClassPath.ClassName)
+        {
+            case "__InstanceCreationEvent":
+            {
+                var targetInstance = e.NewEvent.Properties["TargetInstance"];
+                var win32PnpProperties = ((ManagementBaseObject)targetInstance.Value).Properties;
+                var friendlyName = win32PnpProperties["Caption"].Value.ToString();
+                var deviceId = win32PnpProperties["DeviceID"].Value.ToString()?.Replace("\\", "#").ToLower();
+                var symbolicLink = $"\\\\?\\{deviceId}#{{{KsCategoryVideoCamera}}}\\global";
+                try
+                {
+                    Utils.UIInvokeIfRequired(() => { VideoDevices.Add(new VideoDevice(friendlyName, symbolicLink)); });
+                }
+                catch (SharpGenException)
+                {
+                }
+
+                break;
+            }
+            case "__InstanceDeletionEvent":
+            {
+                var targetInstance = e.NewEvent.Properties["TargetInstance"];
+                var win32PnpProperties = ((ManagementBaseObject)targetInstance.Value).Properties;
+                var deviceId = win32PnpProperties["DeviceID"].Value.ToString()?.Replace("\\", "#").ToLower();
+                try
+                {
+                    Utils.UIInvokeIfRequired(() =>
+                    {
+                        VideoDevices.Remove(VideoDevices.First(vd => vd.SymbolicLink.Contains(deviceId)));
+                    });
+                }
+                catch (InvalidOperationException)
+                {
+                }
+                catch (SharpGenException)
+                {
+                }
+
+                break;
+            }
+        }
+    }
+
+    private void EnumerateVideoDevices()
+    {
+        var mfVideoDevices = MediaFactory.MFEnumVideoDeviceSources();
+        foreach (var mfVideoDevice in mfVideoDevices)
+            VideoDevices.Add(new VideoDevice(mfVideoDevice.FriendlyName,
+                mfVideoDevice.SymbolicLink));
+    }
+}

--- a/FlyleafLib/Engine/VideoDeviceEnumerator/VideoFormat.cs
+++ b/FlyleafLib/Engine/VideoDeviceEnumerator/VideoFormat.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Reflection;
+using FFmpeg.AutoGen;
+using Vortice.MediaFoundation;
+
+namespace FlyleafLib.VideoDeviceEnumerator;
+
+public class VideoFormat : IVideoFormat
+{
+    private static readonly Guid MfMediaTypeVideo =
+        new(0x73646976, 0x0000, 0x0010, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71);
+
+    public VideoFormat(string videoDeviceName, Guid majorType, Guid subType, int frameSizeWidth,
+        int frameSizeHeight, int frameRate,
+        int frameRateDenominator)
+    {
+        DeviceFriendlyName = videoDeviceName;
+        MajorType = MfMediaTypeVideo == majorType ? "Video" : "Unknown";
+        SubType = GetPropertyName(subType);
+        FrameSizeWidth = frameSizeWidth;
+        FrameSizeHeight = frameSizeHeight;
+        FrameRate = frameRate / frameRateDenominator;
+        FFmpegFormat = GetFFmpegFormat(SubType);
+        Uri =
+            $"device://dshow?video={DeviceFriendlyName}&video_size={FrameSizeWidth}x{FrameSizeHeight}&framerate={FrameRate}&{FFmpegFormat}";
+    }
+
+    public VideoFormat(string videoDeviceName, string majorType, string subType, int frameSizeWidth,
+        int frameSizeHeight, int frameRate,
+        int frameRateDenominator)
+    {
+        DeviceFriendlyName = videoDeviceName;
+        MajorType = majorType;
+        SubType = subType;
+        FrameSizeWidth = frameSizeWidth;
+        FrameSizeHeight = frameSizeHeight;
+        FrameRate = frameRate / frameRateDenominator;
+        FFmpegFormat = GetFFmpegFormat(SubType);
+        Uri =
+            $"device://dshow?video={DeviceFriendlyName}&video_size={FrameSizeWidth}x{FrameSizeHeight}&framerate={FrameRate}&{FFmpegFormat}";
+    }
+
+    public string DeviceFriendlyName { get; }
+    public string MajorType { get; }
+    public string SubType { get; }
+    public int FrameSizeWidth { get; }
+    public int FrameSizeHeight { get; }
+    public int FrameRate { get; }
+    private string FFmpegFormat { get; }
+
+    public string Uri { get; }
+
+    public override string ToString()
+    {
+        return $"{SubType}, {FrameSizeWidth}x{FrameSizeHeight}, {FrameRate}FPS";
+    }
+
+    private static string GetPropertyName(Guid guid)
+    {
+        var type = typeof(VideoFormatGuids);
+        foreach (var property in type.GetFields(BindingFlags.Public | BindingFlags.Static))
+            if (property.FieldType == typeof(Guid))
+            {
+                var temp = property.GetValue(null);
+                if (temp is Guid value)
+                    if (value == guid)
+                        return property.Name.ToUpper();
+            }
+
+        return null; // not found
+    }
+
+    private static unsafe string GetFFmpegFormat(string subType)
+    {
+        switch (subType)
+        {
+            case "MJPG":
+                var descriptorPtr = ffmpeg.avcodec_descriptor_get(AVCodecID.AV_CODEC_ID_MJPEG);
+                return $"vcodec={Utils.BytePtrToStringUTF8(descriptorPtr->name)}";
+            case "YUY2":
+                return $"pixel_format={ffmpeg.av_get_pix_fmt_name(AVPixelFormat.AV_PIX_FMT_YUYV422)}";
+            case "NV12":
+                return $"pixel_format={ffmpeg.av_get_pix_fmt_name(AVPixelFormat.AV_PIX_FMT_NV12)}";
+            default:
+                return "";
+        }
+    }
+}

--- a/FlyleafLib/Engine/VideoDeviceEnumerator/VideoFormatsViaMediaSource.cs
+++ b/FlyleafLib/Engine/VideoDeviceEnumerator/VideoFormatsViaMediaSource.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Vortice.MediaFoundation;
+
+namespace FlyleafLib.VideoDeviceEnumerator;
+
+public static class VideoFormatsViaMediaSource
+{
+    private static readonly Guid MfMediaTypeVideo =
+        new(0x73646976, 0x0000, 0x0010, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71);
+
+    public static IEnumerable<IVideoFormat> GetVideoFormatsForVideoDevice(string friendlyName,
+        string symbolicLink)
+    {
+        var formatList = new List<IVideoFormat>();
+
+        using (var mediaSource = GetMediaSourceFromVideoDevice(symbolicLink))
+        {
+            using (var sourcePresentationDescriptor = mediaSource.CreatePresentationDescriptor())
+            {
+                var sourceStreamCount = sourcePresentationDescriptor.StreamDescriptorCount;
+
+                for (var i = 0; i < sourceStreamCount; i++)
+                {
+                    var guidMajorType =
+                        GetMajorMediaTypeFromPresentationDescriptor(sourcePresentationDescriptor, i);
+                    if (guidMajorType != MfMediaTypeVideo) continue;
+
+                    sourcePresentationDescriptor.GetStreamDescriptorByIndex(i, out var streamIsSelected,
+                        out var videoStreamDescriptor);
+
+                    using (videoStreamDescriptor)
+                    {
+                        if (streamIsSelected == false) continue;
+
+                        using (var typeHandler = videoStreamDescriptor.MediaTypeHandler)
+                        {
+                            var mediaTypeCount = typeHandler.MediaTypeCount;
+
+                            for (var mediaTypeId = 0; mediaTypeId < mediaTypeCount; mediaTypeId++)
+                                using (var workingMediaType = typeHandler.GetMediaTypeByIndex(mediaTypeId))
+                                {
+                                    var videoFormat = GetVideoFormatFromMediaType(friendlyName,
+                                        workingMediaType);
+                                    // NV12 and YUY2 are not playable TODO check support for video formats,
+                                    if (videoFormat.SubType != "NV12" && videoFormat.SubType != "YUY2")
+                                        formatList.Add(videoFormat);
+                                }
+                        }
+                    }
+                }
+            }
+        }
+
+        return formatList.OrderBy(format => format.SubType).ThenBy(format => format.FrameSizeHeight)
+            .ThenBy(format => format.FrameRate);
+    }
+
+    private static IMFMediaSource GetMediaSourceFromVideoDevice(string symbolicLink)
+    {
+        using (var attributeContainer = MediaFactory.MFCreateAttributes(2))
+        {
+            attributeContainer.Set(CaptureDeviceAttributeKeys.SourceType,
+                CaptureDeviceAttributeKeys.SourceTypeVidcap);
+
+            attributeContainer.Set(CaptureDeviceAttributeKeys.SourceTypeVidcapSymbolicLink,
+                symbolicLink);
+
+            return MediaFactory.MFCreateDeviceSource(attributeContainer);
+        }
+    }
+
+    private static Guid GetMajorMediaTypeFromPresentationDescriptor(
+        IMFPresentationDescriptor presentationDescriptor,
+        int streamIndex)
+    {
+        presentationDescriptor.GetStreamDescriptorByIndex(streamIndex, out _,
+            out var streamDescriptor);
+
+        using (streamDescriptor)
+        {
+            return GetMajorMediaTypeFromStreamDescriptor(streamDescriptor);
+        }
+    }
+
+    private static Guid GetMajorMediaTypeFromStreamDescriptor(IMFStreamDescriptor streamDescriptor)
+    {
+        using (var pHandler = streamDescriptor.MediaTypeHandler)
+        {
+            var guidMajorType = pHandler.MajorType;
+
+            return guidMajorType;
+        }
+    }
+
+    private static IVideoFormat GetVideoFormatFromMediaType(string videoDeviceName, IMFMediaType mediaType)
+    {
+        // MF_MT_MAJOR_TYPE
+        // Major type GUID, we return this as human readable text
+        var majorType = mediaType.MajorType;
+
+        // MF_MT_SUBTYPE
+        // Subtype GUID which describes the basic media type, we return this as human readable text
+        var subType = mediaType.Get<Guid>(MediaTypeAttributeKeys.Subtype);
+
+        // MF_MT_FRAME_SIZE
+        // the Width and height of a video frame, in pixels
+        MediaFactory.MFGetAttributeSize(mediaType, MediaTypeAttributeKeys.FrameSize, out var frameSizeWidth,
+            out var frameSizeHeight);
+
+        // MF_MT_FRAME_RATE
+        // The frame rate is expressed as a ratio.The upper 32 bits of the attribute value contain the numerator and the lower 32 bits contain the denominator. 
+        // For example, if the frame rate is 30 frames per second(fps), the ratio is 30 / 1.If the frame rate is 29.97 fps, the ratio is 30,000 / 1001.
+        // we report this back to the user as a decimal
+        MediaFactory.MFGetAttributeRatio(mediaType, MediaTypeAttributeKeys.FrameRate, out var frameRate,
+            out var frameRateDenominator);
+
+        var videoFormat = new VideoFormat(videoDeviceName, majorType, subType, (int)frameSizeWidth,
+            (int)frameSizeHeight,
+            (int)frameRate,
+            (int)frameRateDenominator);
+
+        return videoFormat;
+    }
+}

--- a/FlyleafLib/Engine/VideoDeviceEnumerator/VideoFormatsViaMediaSource.cs
+++ b/FlyleafLib/Engine/VideoDeviceEnumerator/VideoFormatsViaMediaSource.cs
@@ -43,8 +43,8 @@ public static class VideoFormatsViaMediaSource
                                 {
                                     var videoFormat = GetVideoFormatFromMediaType(friendlyName,
                                         workingMediaType);
-                                    // NV12 and YUY2 are not playable TODO check support for video formats,
-                                    if (videoFormat.SubType != "NV12" && videoFormat.SubType != "YUY2")
+                                    // NV12 is not playable TODO check support for video formats
+                                    if (videoFormat.SubType != "NV12")
                                         formatList.Add(videoFormat);
                                 }
                         }

--- a/FlyleafLib/FlyleafLib.csproj
+++ b/FlyleafLib/FlyleafLib.csproj
@@ -65,6 +65,8 @@
 
   <ItemGroup>
     <PackageReference Include="FFmpeg.AutoGen" Version="4.4.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
+    <PackageReference Include="System.Management" Version="7.0.0" />
     <PackageReference Include="Vortice.D3DCompiler" Version="2.4.2" />
     <PackageReference Include="Vortice.Direct3D11" Version="2.4.2" />
     <PackageReference Include="Vortice.DirectComposition" Version="2.4.2" />

--- a/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
+++ b/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
@@ -359,7 +359,7 @@ namespace FlyleafLib.MediaFramework.MediaDemuxer
                         
                         Interrupter.Request(Requester.Open);
 
-                        #if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
                         // Workaround to fix a weird issue while opening gdigrab from an non-UI thread after 20-40 sec. of demuxing
                         // [gdigrab @ 0000019affe3f2c0] Failed to capture image (error 6) or (error 8)
                         // Update: Same happens with other av device formats (such as decklink)
@@ -370,19 +370,23 @@ namespace FlyleafLib.MediaFramework.MediaDemuxer
                                 // TODO use ffmpeg.av_dict_free(ref AVDictionary*) to dispose of avopt?
                                 AVDictionary* avopt = null;
                                 foreach (var optKV in curFormats) av_dict_set(&avopt, optKV.Key, optKV.Value, 0);
-                                foreach (var deviceParameter in deviceParameters) av_dict_set(&avopt, deviceParameter.Key, deviceParameter.Value, 0);
+                                if (deviceParameters != null)
+                                    foreach (var deviceParameter in deviceParameters)
+                                        av_dict_set(&avopt, deviceParameter.Key, deviceParameter.Value, 0);
                                 AVFormatContext* fmtCtxPtr = fmtCtx;
                                 ret = avformat_open_input(&fmtCtxPtr, deviceUrl, inFmt, &avopt);
                             });
                         else
                         {
 #endif
-                            // TODO use ffmpeg.av_dict_free(ref AVDictionary*) to dispose of avopt?
-                            AVDictionary* avopt = null;
-                            foreach (var optKV in curFormats) av_dict_set(&avopt, optKV.Key, optKV.Value, 0);
-                            foreach (var deviceParameter in deviceParameters) av_dict_set(&avopt, deviceParameter.Key, deviceParameter.Value, 0);
-                            AVFormatContext* fmtCtxPtr = fmtCtx;
-                            ret = avformat_open_input(&fmtCtxPtr, stream != null ? null : (deviceUrl ?? url), inFmt, &avopt);
+                        // TODO use ffmpeg.av_dict_free(ref AVDictionary*) to dispose of avopt?
+                        AVDictionary* avopt = null;
+                        foreach (var optKV in curFormats) av_dict_set(&avopt, optKV.Key, optKV.Value, 0);
+                        if (deviceParameters != null)
+                            foreach (var deviceParameter in deviceParameters)
+                                av_dict_set(&avopt, deviceParameter.Key, deviceParameter.Value, 0);
+                        AVFormatContext* fmtCtxPtr = fmtCtx;
+                        ret = avformat_open_input(&fmtCtxPtr, stream != null ? null : (deviceUrl ?? url), inFmt, &avopt);
                         #if NET6_0_OR_GREATER
                         }
                         #endif

--- a/Samples/FlyleafPlayer (WPF Control) (WPF)/Dictionary.xaml
+++ b/Samples/FlyleafPlayer (WPF Control) (WPF)/Dictionary.xaml
@@ -1,9 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     
-                    xmlns:collections="clr-namespace:System.Collections;assembly=mscorlib"
                     xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-                    >
+                    xmlns:flyleafLib="clr-namespace:FlyleafLib;assembly=FlyleafLib">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/FlyleafLib.Controls.WPF;component/Resources/MaterialDesign.xaml"/>
@@ -13,8 +12,12 @@
     
     <!--Overriding FlyleafME's Popup Menu (Using FlyleafME's Tag to pass our DataContext) -->
     <ContextMenu x:Key="PopUpMenu" Style="{StaticResource FlyleafContextMenu}">
-        <MenuItem Header="Open File" Command="{Binding OpenFileDialog}" Icon="{materialDesign:PackIcon FolderOutline}"/>
-        <MenuItem Header="Paste Url" Command="{Binding Player.Commands.OpenFromClipboard}" IsEnabled="{Binding CanPaste}" Icon="{materialDesign:PackIcon ContentPaste}"/>
+        <MenuItem Header="Open File" Command="{Binding OpenFileDialog}" Icon="{materialDesign:PackIcon FolderOutline}" />
+        <MenuItem Header="Paste Url" Command="{Binding Player.Commands.OpenFromClipboard}"
+                  IsEnabled="{Binding CanPaste}" Icon="{materialDesign:PackIcon ContentPaste}" />
+        <MenuItem Header="Open Device" Icon="{materialDesign:PackIcon VideoOutline}" IsEnabled="{Binding VideoDevices.Count, Source={x:Static flyleafLib:Engine.Video}}"
+                  ItemsSource="{Binding VideoDevices, Source={x:Static flyleafLib:Engine.Video}}"
+                  ItemTemplate="{StaticResource VideoDeviceMenuHierarchyTemplate}" />
         <Separator />
         
         <MenuItem Header="New Window" Command="{Binding Tag.OpenWindow}" Icon="{materialDesign:PackIcon Kind=TabPlus}"/>

--- a/Samples/FlyleafPlayer (WPF Control) (WPF)/Dictionary.xaml
+++ b/Samples/FlyleafPlayer (WPF Control) (WPF)/Dictionary.xaml
@@ -15,8 +15,8 @@
         <MenuItem Header="Open File" Command="{Binding OpenFileDialog}" Icon="{materialDesign:PackIcon FolderOutline}" />
         <MenuItem Header="Paste Url" Command="{Binding Player.Commands.OpenFromClipboard}"
                   IsEnabled="{Binding CanPaste}" Icon="{materialDesign:PackIcon ContentPaste}" />
-        <MenuItem Header="Open Device" Icon="{materialDesign:PackIcon VideoOutline}" IsEnabled="{Binding VideoDevices.Count, Source={x:Static flyleafLib:Engine.Video}}"
-                  ItemsSource="{Binding VideoDevices, Source={x:Static flyleafLib:Engine.Video}}"
+        <MenuItem Header="Open Device" Icon="{materialDesign:PackIcon VideoOutline}" IsEnabled="{Binding CapDevices.Count, Source={x:Static flyleafLib:Engine.Video}}"
+                  ItemsSource="{Binding CapDevices, Source={x:Static flyleafLib:Engine.Video}}"
                   ItemTemplate="{StaticResource VideoDeviceMenuHierarchyTemplate}" />
         <Separator />
         


### PR DESCRIPTION
Engine: Add enumerator for usb webcams.
Demuxer: Add support for dshow device parameters.
FlyleafPlayer (WPF Control): Add "Open Device" menu.

Issues:
1. IMPORTANT! Usb webcam has noticeable latency. Setting MaxLatency to 1 and then to 0 fixes this. What is the reason?
2. Flyleaf does not play NV12. NV12 throws -5 on avformat_open_input.  Maybe there are other not supported webcam video formats?
3. Should ffmpeg.av_dict_free(ref AVDictionary*) be used to dispose of avopt in Demuxer?
