### PR TITLE
Use generics for DeviceBase DeviceStreamBase.

### DIFF
--- a/FlyleafLib/MediaFramework/MediaDevice/AudioDevice.cs
+++ b/FlyleafLib/MediaFramework/MediaDevice/AudioDevice.cs
@@ -3,7 +3,7 @@ using Vortice.MediaFoundation;
 
 namespace FlyleafLib.MediaFramework.MediaDevice;
 
-public class AudioDevice : DeviceBase
+public class AudioDevice : DeviceBase<AudioDeviceStream>
 {
     public AudioDevice(string friendlyName, string symbolicLink) : base(friendlyName, symbolicLink)
         => Url = $"fmt://dshow?audio={FriendlyName}";

--- a/FlyleafLib/MediaFramework/MediaDevice/DeviceBase.cs
+++ b/FlyleafLib/MediaFramework/MediaDevice/DeviceBase.cs
@@ -2,11 +2,19 @@
 
 namespace FlyleafLib.MediaFramework.MediaDevice;
 
-public class DeviceBase
+public class DeviceBase :DeviceBase<DeviceStreamBase>
+{
+    public DeviceBase(string friendlyName, string symbolicLink) : base(friendlyName, symbolicLink)
+    {
+    }
+}
+
+public class DeviceBase<T>
+    where T: DeviceStreamBase
 {
     public string   FriendlyName            { get; }
     public string   SymbolicLink            { get; }
-    public IEnumerable<DeviceStreamBase> 
+    public IEnumerable<T> 
                     Streams                 { get; protected set; }
     public string   Url                     { get; protected set; } // default Url
 

--- a/FlyleafLib/MediaFramework/MediaDevice/DeviceBase.cs
+++ b/FlyleafLib/MediaFramework/MediaDevice/DeviceBase.cs
@@ -14,7 +14,7 @@ public class DeviceBase<T>
 {
     public string   FriendlyName            { get; }
     public string   SymbolicLink            { get; }
-    public IEnumerable<T> 
+    public IList<T> 
                     Streams                 { get; protected set; }
     public string   Url                     { get; protected set; } // default Url
 

--- a/FlyleafLib/MediaFramework/MediaDevice/VideoDevice.cs
+++ b/FlyleafLib/MediaFramework/MediaDevice/VideoDevice.cs
@@ -5,12 +5,12 @@ using Vortice.MediaFoundation;
 
 namespace FlyleafLib.MediaFramework.MediaDevice;
 
-public class VideoDevice : DeviceBase
+public class VideoDevice : DeviceBase<VideoDeviceStream>
 {
     public VideoDevice(string friendlyName, string symbolicLink) : base(friendlyName, symbolicLink)
     {
         Streams = VideoDeviceStream.GetVideoFormatsForVideoDevice(friendlyName, symbolicLink);
-        Url = Streams.OfType<VideoDeviceStream>().Where(f => f.SubType.Contains("MJPG") && f.FrameRate >= 30).OrderByDescending(f => f.FrameSizeHeight).FirstOrDefault().Url;
+        Url = Streams.Where(f => f.SubType.Contains("MJPG") && f.FrameRate >= 30).OrderByDescending(f => f.FrameSizeHeight).FirstOrDefault()?.Url;
     }
 
     public static void RefreshDevices()

--- a/FlyleafLib/MediaFramework/MediaDevice/VideoDeviceStream.cs
+++ b/FlyleafLib/MediaFramework/MediaDevice/VideoDeviceStream.cs
@@ -61,7 +61,7 @@ public class VideoDeviceStream : DeviceStreamBase
     public override string ToString() => $"{SubType}, {FrameSizeWidth}x{FrameSizeHeight}, {FrameRate}FPS";
 
     #region VideoFormatsViaMediaSource
-    public static IEnumerable<VideoDeviceStream> GetVideoFormatsForVideoDevice(string friendlyName, string symbolicLink)
+    public static IList<VideoDeviceStream> GetVideoFormatsForVideoDevice(string friendlyName, string symbolicLink)
     {
         List<VideoDeviceStream> formatList = new();
 
@@ -101,7 +101,7 @@ public class VideoDeviceStream : DeviceStreamBase
             }
         }
 
-        return formatList.OrderBy(format => format.SubType).ThenBy(format => format.FrameSizeHeight).ThenBy(format => format.FrameRate);
+        return formatList.OrderBy(format => format.SubType).ThenBy(format => format.FrameSizeHeight).ThenBy(format => format.FrameRate).ToList();
     }
 
     private static IMFMediaSource GetMediaSourceFromVideoDevice(string symbolicLink)

--- a/FlyleafLib/MediaFramework/MediaDevice/VideoDeviceStream.cs
+++ b/FlyleafLib/MediaFramework/MediaDevice/VideoDeviceStream.cs
@@ -61,7 +61,7 @@ public class VideoDeviceStream : DeviceStreamBase
     public override string ToString() => $"{SubType}, {FrameSizeWidth}x{FrameSizeHeight}, {FrameRate}FPS";
 
     #region VideoFormatsViaMediaSource
-    public static IEnumerable<DeviceStreamBase> GetVideoFormatsForVideoDevice(string friendlyName, string symbolicLink)
+    public static IEnumerable<VideoDeviceStream> GetVideoFormatsForVideoDevice(string friendlyName, string symbolicLink)
     {
         List<VideoDeviceStream> formatList = new();
 


### PR DESCRIPTION
Enables more concise access to VideoDeviceStream properties:
```
var height= Engine.Video.CapDevices[0].Streams[0].FrameSizeHeight;
```
instead of:
```
var height = ((VideoDeviceStream)Engine.Video.CapDevices[0].Streams.First()).FrameSizeHeight;
```