### PR TITLE
Allow more time for first frame - critical for static images to be reliably displayed

### DIFF
--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
@@ -21,7 +21,7 @@ public unsafe partial class Renderer
 
     public bool Present(VideoFrame frame)
     {
-        if (Monitor.TryEnter(lockDevice, 5))
+        if (Monitor.TryEnter(lockDevice, frame.timestamp == 0 ? 100 : 5)) // Allow more time for first frame
         {
             try
             {


### PR DESCRIPTION
Have found from a lot of playing static images that sometimes they are not successfully presented and just leave a black screen.

Narrowed down to a line of code in the renderer that only allows 5mS for the lock on the device to become available otherwise the frame is dropped. Clearly there is the odd occasion where 5mS is not quite enough. This could be exacerbated by having multiple players running simultaneously where images are being opened on all players at the same time. (Which is what I was doing).

This PR increases the time to 100mS, but only for the very first frame.