### PR TITLE
Allow streams/files with at least one good video track

### DIFF
--- a/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
+++ b/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
@@ -623,7 +623,7 @@ public unsafe class Demuxer : RunThreadBase
 
                         VideoStreams.Add(new VideoStream(this, fmtCtx->streams[i]));
                         AVStreamToStream.Add(fmtCtx->streams[i]->index, VideoStreams[^1]);
-                        hasVideo = !Config.AllowFindStreamInfo || VideoStreams[^1].PixelFormat != AVPixelFormat.AV_PIX_FMT_NONE;
+                        hasVideo |= !Config.AllowFindStreamInfo || VideoStreams[^1].PixelFormat != AVPixelFormat.AV_PIX_FMT_NONE;
 
                         break;
 


### PR DESCRIPTION
If a stream or a file has valid video tracks, but the last video track is corrupt, empty or otherwise unreadable, the whole stream or file is marked as not having video.
This allows the player to support more streams and video files.

Can also consider adding a check so that invalid video tracks are not added to the available streams.