### PR TITLE
Sync with local

### DIFF
--- a/FlyleafLib/Controls/WPF/FlyleafHost.cs
+++ b/FlyleafLib/Controls/WPF/FlyleafHost.cs
@@ -1130,6 +1130,8 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
             if (text.Length > 0)
                 Player.OpenAsync(text);
         }
+
+        Surface.Activate();
     }
     private void Overlay_Drop(object sender, DragEventArgs e)
     {
@@ -1162,6 +1164,8 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
             if (text.Length > 0)
                 Player.OpenAsync(text);
         }
+
+        Overlay.Activate();
     }
     private void Surface_DragEnter(object sender, DragEventArgs e) { if (Player != null) e.Effects = DragDropEffects.All; }
     private void Overlay_DragEnter(object sender, DragEventArgs e) { if (Player != null) e.Effects = DragDropEffects.All; }

--- a/FlyleafLib/Controls/WPF/PlayerDebug.xaml
+++ b/FlyleafLib/Controls/WPF/PlayerDebug.xaml
@@ -47,8 +47,9 @@
             </Style>
         </ResourceDictionary>
     </UserControl.Resources>
-
-    <Grid>
+    <StackPanel>
+        <TextBlock HorizontalAlignment="Left" Background="{Binding BoxColor, ElementName=DebugControl}" Style="{StaticResource TextValue}" Padding="10" Width="690" TextWrapping="Wrap" Text="{Binding Player.Playlist.Url}"/>    
+        <Grid x:Name="rootGrid">
         <Grid.ColumnDefinitions>
             <ColumnDefinition/>
             <ColumnDefinition/>
@@ -354,5 +355,6 @@
             </StackPanel>
         </StackPanel>
     </Grid>
+    </StackPanel>
 </UserControl>
 

--- a/FlyleafLib/MediaFramework/FFmpegBindings/ffmpegEx.cs
+++ b/FlyleafLib/MediaFramework/FFmpegBindings/ffmpegEx.cs
@@ -117,6 +117,7 @@ internal unsafe partial class ffmpegEx
     #endregion
 
     #region av_display_rotation_get
+    // TBR: This possible has issues with negatives, should update FFmpeg.Autogen to 6?
     static double Hypot(double x, double y) => Math.Sqrt(Math.Pow(x, 2) + Math.Pow(y, 2));
     static double CONVFP(double x) => x / (1 << 16);
     public static double av_display_rotation_get(byte* matrixBytes)
@@ -124,7 +125,7 @@ internal unsafe partial class ffmpegEx
         if (matrixBytes == null)
             return 0;
 
-        var matrix = (UInt32*) matrixBytes;
+        var matrix = (int*) matrixBytes;
 
         double[] scale = new double[2];
 
@@ -136,7 +137,7 @@ internal unsafe partial class ffmpegEx
 
         double rotation = -(Math.Atan2(CONVFP(matrix[1]) / scale[1], CONVFP(matrix[0]) / scale[0]) * 180 / Math.PI);
         
-        return rotation < 0 ? 360 + rotation : rotation;
+        return (((int)(-rotation) % 360) + 360) % 360;
     }
     #endregion
 
@@ -270,3 +271,4 @@ internal unsafe partial class ffmpegEx
 #pragma warning restore CS0169
 #pragma warning restore CS0649
 }
+    

--- a/FlyleafLib/MediaFramework/MediaContext/DecoderContext.Open.cs
+++ b/FlyleafLib/MediaFramework/MediaContext/DecoderContext.Open.cs
@@ -819,6 +819,10 @@ public partial class DecoderContext
                 }
             }
 
+            // 4. Prevent Local/Online Search for 'small' duration videos
+            if (VideoDemuxer.Duration < TimeSpan.FromMinutes(25).Ticks)
+                return;
+
         } catch (Exception e)
         {
             Log.Debug($"OpenSuggestedSubtitles canceled? [{e.Message}]");
@@ -838,11 +842,8 @@ public partial class DecoderContext
                 ExternalSubtitlesStream extStream;
 
                 // 4. Search offline if allowed (not async)
-                if (!Playlist.Selected.SearchedLocal && Config.Subtitles.SearchLocal && (Config.Subtitles.SearchLocalOnInputType == null || Config.Subtitles.SearchLocalOnInputType.Count == 0 || Config.Subtitles.SearchLocalOnInputType.Contains(Playlist.InputType)))
+                if (SearchLocalSubtitles())
                 {
-                    Log.Debug("[Subtitles] Searching Local");
-                    SearchLocalSubtitles();
-
                     // 4.1 Check external streams for high suggest (again for the new additions if any)
                     extStream = SuggestBestExternalSubtitles();
                     if (extStream != null)

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
@@ -708,11 +708,18 @@ color = float4(Texture1.Sample(Sampler, input.Texture).rgb, 1.0);
                         subData[0].DataPointer  = (IntPtr) frame->data[i];
                         subData[0].DataPointer -= (subData[0].RowPitch * (VideoStream.Height - 1));
                         
-                    } else
+                    }
+                    else
                     {
                         newRotationLinesize     = false;
                         subData[0].RowPitch     = frame->linesize[i];
                         subData[0].DataPointer  = (IntPtr) frame->data[i];
+                    }
+
+                    if (subData[0].RowPitch < textDesc[i].Width) // Prevent reading more than the actual data (Access Violation #424)
+                    {
+                        av_frame_unref(frame);
+                        return null;
                     }
 
                     mFrame.textures[i]  = Device.CreateTexture2D(textDesc[i], subData);

--- a/FlyleafLib/MediaPlayer/Player.Keys.cs
+++ b/FlyleafLib/MediaPlayer/Player.Keys.cs
@@ -158,7 +158,14 @@ public class KeysConfig
     {
         for (int i=0; i<Keys.Count; i++)
             if (Keys[i].Key == key && Keys[i].Alt == alt && Keys[i].Ctrl == ctrl && Keys[i].Shift == shift)
-                throw new Exception($"Keybinding {(alt ? "Alt + " : "")}{(ctrl ? "Ctrl + " : "")}{(shift ? "Shift + " : "")}{key} already assigned");
+            {
+                Keys[i].IsKeyUp = isKeyUp;
+                Keys[i].Action = KeyBindingAction.Custom;
+                Keys[i].ActionName = actionName;
+                Keys[i].ActionInternal = action;
+
+                return;
+            }
 
         Keys.Add(new KeyBinding() { Alt = alt, Ctrl = ctrl, Shift = shift, Key = key, IsKeyUp = isKeyUp, Action = KeyBindingAction.Custom, ActionName = actionName, ActionInternal = action });
     }
@@ -176,7 +183,13 @@ public class KeysConfig
     {
         for (int i=0; i<Keys.Count; i++)
             if (Keys[i].Key == key && Keys[i].Alt == alt && Keys[i].Ctrl == ctrl && Keys[i].Shift == shift)
-                throw new Exception($"Keybinding {(alt ? "Alt + " : "")}{(ctrl ? "Ctrl + " : "")}{(shift ? "Shift + " : "")}{key} already assigned");
+            {
+                Keys[i].IsKeyUp = isKeyUpBinding.Contains(action);
+                Keys[i].Action = action;
+                Keys[i].ActionInternal = player != null ? GetKeyBindingAction(action) : null;
+
+                return;
+            }
 
         if (player == null)
             Keys.Add(new KeyBinding() { Alt = alt, Ctrl = ctrl, Shift = shift, Key = key, IsKeyUp = isKeyUpBinding.Contains(action), Action = action });

--- a/FlyleafLib/Plugins/PluginHandler.cs
+++ b/FlyleafLib/Plugins/PluginHandler.cs
@@ -401,18 +401,26 @@ public class PluginHandler
         return null;
     }
 
-    public void SearchLocalSubtitles()
+    public bool SearchLocalSubtitles()
     {
-        var plugins = PluginsSearchLocalSubtitles.Values.OrderBy(x => x.Priority);
-        foreach(var plugin in plugins)
+        if (!Playlist.Selected.SearchedLocal && Config.Subtitles.SearchLocal && (Config.Subtitles.SearchLocalOnInputType == null || Config.Subtitles.SearchLocalOnInputType.Count == 0 || Config.Subtitles.SearchLocalOnInputType.Contains(Playlist.InputType)))
         {
-            if (Interrupt)
-                return;
+            Log.Debug("[Subtitles] Searching Local");
+            var plugins = PluginsSearchLocalSubtitles.Values.OrderBy(x => x.Priority);
+            foreach(var plugin in plugins)
+            {
+                if (Interrupt)
+                    return false;
 
-            plugin.SearchLocalSubtitles();
+                plugin.SearchLocalSubtitles();
+            }
+
+            Playlist.Selected.SearchedLocal = true;
+
+            return true;
         }
 
-        Playlist.Selected.SearchedLocal = true;
+        return false;
     }
     public void SearchOnlineSubtitles()
     {

--- a/Samples/FlyleafPlayer (WPF Control) (WPF)/MainWindow.xaml
+++ b/Samples/FlyleafPlayer (WPF Control) (WPF)/MainWindow.xaml
@@ -10,10 +10,11 @@
         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
         mc:Ignorable="d"
         FontFamily="{materialDesign:MaterialDesignFont}"
-        TextElement.FontWeight="Regular"
-        TextElement.FontSize="13"
         TextOptions.TextFormattingMode="Ideal"
-        TextOptions.TextRenderingMode="Auto"
+        TextOptions.TextRenderingMode="Auto"        
+        TextElement.Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+        TextElement.FontWeight="Medium"
+        TextElement.FontSize="14"
         
         Title="Flyleaf" WindowStyle="None" ResizeMode="NoResize" AllowsTransparency="True" Background="Transparent"
         
@@ -69,124 +70,283 @@
         </Border.Style>
         <Border BorderThickness="6 2 6 2" BorderBrush="#01000000">
             <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <Grid Grid.Row="0" x:Name="HeaderGrid" Margin="-2 0 -2 0">
-                    <Grid.Background>
-                        <SolidColorBrush Color="{Binding Player.Config.Video.BackgroundColor}" Opacity="0.15"/>
-                    </Grid.Background>
+                <Grid>
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="50"/>
+                        <RowDefinition Height="auto"/>
+                        <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="auto"/>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="auto"/>
-                    </Grid.ColumnDefinitions>
-                    <Grid.Style>
-                        <Style TargetType="{x:Type Grid}">
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding Player.Activity.Mode}" Value="Idle">
-                                    <DataTrigger.EnterActions>
-                                        <RemoveStoryboard BeginStoryboardName="fadeInN" />
-                                        <BeginStoryboard x:Name="fadeOutN" Storyboard="{StaticResource fadeOut}" />
-                                    </DataTrigger.EnterActions>
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding Player.Activity.Mode}" Value="Active">
-                                    <DataTrigger.EnterActions>
-                                        <RemoveStoryboard BeginStoryboardName="fadeInN" />
-                                        <BeginStoryboard x:Name="fadeOutN2" Storyboard="{StaticResource fadeOut}" />
-                                    </DataTrigger.EnterActions>
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding Player.Activity.Mode, FallbackValue=FullActive, TargetNullValue=FullActive}" Value="FullActive">
-                                    <DataTrigger.EnterActions>
-                                        <RemoveStoryboard BeginStoryboardName="fadeOutN" />
-                                        <RemoveStoryboard BeginStoryboardName="fadeOutN2" />
-                                        <BeginStoryboard x:Name="fadeInN" Storyboard="{StaticResource fadeIn}" />
-                                    </DataTrigger.EnterActions>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </Grid.Style>
                     
-                    <Image Source="Flyleaf.ico" Stretch="UniformToFill" Height="40" Margin="5 0 0 0" VerticalAlignment="Center" ToolTip="{Binding Tag.FlyleafLibVer}"/>
+                    <!--Title Bar-->
+                    <Grid Grid.Row="0" x:Name="HeaderGrid" Margin="-2 0 -2 0">
+                        <Grid.Background>
+                            <SolidColorBrush Color="{Binding Player.Config.Video.BackgroundColor}" Opacity="0.15"/>
+                        </Grid.Background>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="50"/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="auto"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.Style>
+                            <Style TargetType="{x:Type Grid}">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Player.Activity.Mode}" Value="Idle">
+                                        <DataTrigger.EnterActions>
+                                            <RemoveStoryboard BeginStoryboardName="fadeInN" />
+                                            <BeginStoryboard x:Name="fadeOutN" Storyboard="{StaticResource fadeOut}" />
+                                        </DataTrigger.EnterActions>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Player.Activity.Mode}" Value="Active">
+                                        <DataTrigger.EnterActions>
+                                            <RemoveStoryboard BeginStoryboardName="fadeInN" />
+                                            <BeginStoryboard x:Name="fadeOutN2" Storyboard="{StaticResource fadeOut}" />
+                                        </DataTrigger.EnterActions>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Player.Activity.Mode, FallbackValue=FullActive, TargetNullValue=FullActive}" Value="FullActive">
+                                        <DataTrigger.EnterActions>
+                                            <RemoveStoryboard BeginStoryboardName="fadeOutN" />
+                                            <RemoveStoryboard BeginStoryboardName="fadeOutN2" />
+                                            <BeginStoryboard x:Name="fadeInN" Storyboard="{StaticResource fadeIn}" />
+                                        </DataTrigger.EnterActions>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Grid.Style>
 
-                    <TextBlock Grid.ColumnSpan="3" HorizontalAlignment="Center" VerticalAlignment="Center" Text="Flyleaf" FontWeight="Bold" FontStyle="Italic" FontFamily="Mistral" FontSize="34" Foreground="{DynamicResource MaterialDesign.Brush.Primary}"/>
+                        <StackPanel Orientation="Horizontal">
+                            <Image Source="Flyleaf.ico" Stretch="UniformToFill" Height="40" Margin="5 0 0 0" VerticalAlignment="Center" ToolTip="{Binding Tag.FlyleafLibVer}"/>
+                            <TextBlock Margin="10 0 0 0" Text="{Binding Tag.ImageTitle}" d:Text="Test.jpg" VerticalAlignment="Center" Foreground="{DynamicResource MaterialDesign.Brush.Secondary}"/>
+                        </StackPanel>
+                        <TextBlock Grid.ColumnSpan="3" HorizontalAlignment="Center" VerticalAlignment="Center" Text="Flyleaf" FontWeight="Bold" FontStyle="Italic" FontFamily="Mistral" FontSize="34" Foreground="{DynamicResource MaterialDesign.Brush.Primary}"/>
 
-                    <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right">
-                        <ToggleButton Style="{StaticResource MaterialDesignActionToggleButton}" Focusable="False" ToolTip="Always on Top" Background="Transparent" Foreground="{DynamicResource MaterialDesign.Brush.Primary}"
+                        <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right">
+                            <ToggleButton Style="{StaticResource MaterialDesignActionToggleButton}" Focusable="False" ToolTip="Always on Top" Background="Transparent" Foreground="{DynamicResource MaterialDesign.Brush.Primary}"
                                   Content="{materialDesign:PackIcon Kind=PinOutline}" materialDesign:ToggleButtonAssist.OnContent="{materialDesign:PackIcon Kind=Pin}" IsChecked="{Binding DetachedTopMost}"/>
-                        
-                        <Button Focusable="False" x:Name="BtnMinimize" Content="{materialDesign:PackIcon Kind=Minimize,Size=30}" VerticalContentAlignment="Bottom" Style="{StaticResource MaterialDesignIconButton}" Click="BtnMinimize_Click"/>
-                        <ToggleButton Grid.Column="6" Style="{StaticResource MaterialDesignActionToggleButton}" Foreground="{DynamicResource MaterialDesign.Brush.Primary}" Background="Transparent" Focusable="False"
+                            <Button Focusable="False" Content="{materialDesign:PackIcon Kind=SettingsOutline,Size=22}" Command="{Binding OpenSettingsCmd, ElementName=FLBar}">
+                                <Button.Style>
+                                    <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignIconButton}">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>    
+                                            <DataTrigger Binding="{Binding Tag.MediaViewer}" Value="Video">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
+                            </Button>
+                            <Button Focusable="False" x:Name="BtnMinimize" Content="{materialDesign:PackIcon Kind=Minimize}" VerticalContentAlignment="Bottom" Style="{StaticResource MaterialDesignIconButton}" Click="BtnMinimize_Click"/>
+                            <ToggleButton Style="{StaticResource MaterialDesignActionToggleButton}" Foreground="{DynamicResource MaterialDesign.Brush.Primary}" Background="Transparent" Focusable="False"
                                                           IsChecked="{Binding Player.Host.IsFullScreen}" 
                                                           Content="{materialDesign:PackIcon Kind=Fullscreen, Size=28}" 
                                                           materialDesign:ToggleButtonAssist.OnContent="{materialDesign:PackIcon Kind=FullscreenExit, Size=28}"/>
-                        <Button x:Name="BtnClose" Click="BtnClose_Click" Content="{materialDesign:PackIcon Kind=Close,Size=30}" Style="{StaticResource MaterialDesignIconButton}" />
-                    </StackPanel>
+                            <Button x:Name="BtnClose" Click="BtnClose_Click" Content="{materialDesign:PackIcon Kind=Close,Size=30}" Style="{StaticResource MaterialDesignIconButton}" />
+                        </StackPanel>
 
-                </Grid>
-
-                <Grid Grid.Row="1" x:Name="PART_ContextMenuOwner" ContextMenu="{StaticResource PopUpMenu}">
-
-                    <TextBlock VerticalAlignment="Top" HorizontalAlignment="Left" Padding="4" Margin="10 -40 0 0" d:Text="00:00:00.000 / 01:42:23.913" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource MaterialDesign.Brush.Secondary}">
-                        <TextBlock.Background>
-                            <SolidColorBrush Color="{Binding Player.Config.Video.BackgroundColor}" Opacity="0.15"/>
-                        </TextBlock.Background>
-                        <TextBlock.Style>
-                            <Style TargetType="{x:Type TextBlock}">
-                                <Setter Property="Visibility" Value="Collapsed"/>
+                    </Grid>
+                    
+                    <!--Video View-->
+                    <Grid Grid.Row="1" x:Name="PART_ContextMenuOwner" ContextMenu="{StaticResource PopUpMenu}">
+                        <Grid.Style>
+                            <Style TargetType="{x:Type Grid}">
+                                <Setter Property="Visibility" Value="Collapsed" d:Value="Visible"/>
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Player.Activity.Mode}" Value="Active" d:Value="{x:Null}">
+                                    <DataTrigger Binding="{Binding Tag.MediaViewer}" Value="Video">
                                         <Setter Property="Visibility" Value="Visible"/>
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
-                        </TextBlock.Style>
+                        </Grid.Style>
+                        <TextBlock VerticalAlignment="Top" HorizontalAlignment="Left" Padding="4" Margin="10 -40 0 0" d:Text="00:00:00.000 / 01:42:23.913" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource MaterialDesign.Brush.Secondary}">
+                            <TextBlock.Background>
+                                <SolidColorBrush Color="{Binding Player.Config.Video.BackgroundColor}" Opacity="0.15"/>
+                            </TextBlock.Background>
+                            <TextBlock.Style>
+                                <Style TargetType="{x:Type TextBlock}">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Player.Activity.Mode}" Value="Active" d:Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
                         <Run Text="{Binding Player.CurTime, Mode=OneWay, Converter={StaticResource TicksToTimeSpan}, StringFormat={}{0:hh\\:mm\\:ss\\.fff}}"/>
                         <Run Text="/"/>
                         <Run Text="{Binding Player.Duration, Mode=OneWay, Converter={StaticResource TicksToTimeSpan}, StringFormat={}{0:hh\\:mm\\:ss\\.fff}}"/>
-                    </TextBlock>
+                        </TextBlock>
+                        
+                        <!--Messages-->
+                        <TextBlock VerticalAlignment="Top" HorizontalAlignment="Right" Padding="4" Margin="0 10 10 0" FontWeight="Bold" d:Text="Volume 50%" FontSize="14" Text="{Binding Tag.Msg}" Foreground="{DynamicResource MaterialDesign.Brush.Secondary}">
+                            <TextBlock.Background>
+                                <SolidColorBrush Color="{Binding Player.Config.Video.BackgroundColor}" Opacity="0.15"/>
+                            </TextBlock.Background>
+                            <TextBlock.Style>
+                                <Style TargetType="{x:Type TextBlock}">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Player.Activity.Mode}" Value="Idle" d:Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </DataTrigger>
+                                        <Trigger Property="Text" Value="">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                        
+                        <!--Status-->
+                        <TextBlock VerticalAlignment="Top" HorizontalAlignment="Right" Padding="4" Margin="0 -40 10 0" FontWeight="Bold" d:Text="Playing" FontSize="18" Text="{Binding Player.Status}" Foreground="{DynamicResource MaterialDesign.Brush.Secondary}">
+                            <TextBlock.Background>
+                                <SolidColorBrush Color="{Binding Player.Config.Video.BackgroundColor}" Opacity="0.15"/>
+                            </TextBlock.Background>
+                            <TextBlock.Style>
+                                <Style TargetType="{x:Type TextBlock}">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Player.Activity.Mode}" Value="Active" d:Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+
+                        <!--Pop Up Dialog (Settings/Set Values)-->
+                        <materialDesign:DialogHost x:Name="PART_DialogSettings" OverlayBackground="{x:Null}"/>
+                        
+                        <!--Subtitles-->
+                        <flwpf:OutlinedTextBlock Stroke="{Binding Player.Config.Video.BackgroundColor, Converter={StaticResource ColorToBrush}}" 
+                         ClipToBounds="False"
+                         Fill="{Binding UIConfig.SubsFontColor, Converter={StaticResource ColorToBrush}}"
+                         StrokePosition="Outside"
+                         StrokeThicknessInitial="{Binding UIConfig.SubsStrokeThickness}"
+                         Margin="{Binding UIConfig.SubsMargin2}"
+                         VerticalAlignment="Bottom"
+                         HorizontalAlignment="Center"
+                         TextAlignment="Center"
+                         TextWrapping="Wrap"
+                         FontFamily="{Binding UIConfig.SubsFontFamily}"
+                         FontSizeInitial="{Binding UIConfig.SubsFontSize}"
+                         FontWeight="{Binding UIConfig.SubsFontWeight}"
+                         FontStyle="{Binding UIConfig.SubsFontStyle}"
+                         Text="{Binding Player.Subtitles.SubsText}">
+                        </flwpf:OutlinedTextBlock>
+
+                        <!--Flyleaf Bar-->
+                        <flwpf:FlyleafBar x:Name="FLBar" Player="{Binding Player}" Margin="-2 0 -2 0"/>
+                    </Grid>
                     
-                    <TextBlock VerticalAlignment="Top" HorizontalAlignment="Right" Padding="4" Margin="0 10 10 0" FontWeight="Bold" d:Text="Volume 50%" FontSize="14" Text="{Binding Tag.Msg}" Foreground="{DynamicResource MaterialDesign.Brush.Secondary}">
-                        <TextBlock.Background>
-                            <SolidColorBrush Color="{Binding Player.Config.Video.BackgroundColor}" Opacity="0.15"/>
-                        </TextBlock.Background>
-                        <TextBlock.Style>
-                            <Style TargetType="{x:Type TextBlock}">
-                                <Setter Property="Visibility" Value="Visible"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Player.Activity.Mode}" Value="Idle" d:Value="{x:Null}">
-                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                    </DataTrigger>
-                                    <Trigger Property="Text" Value="">
-                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                    </Trigger>
-                                </Style.Triggers>
-                            </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
+                    <!--Slide View-->
+                    <materialDesign:DialogHost Grid.Row="0" Grid.RowSpan="2">
+                        <Grid>
+                            <Grid.Style>
+                                <Style TargetType="{x:Type Grid}">
+                                    <Setter Property="Visibility" Value="Collapsed" d:Value="Visible"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Tag.MediaViewer}" Value="Slide">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding Player.Activity.Mode}" Value="Idle">
+                                            <DataTrigger.EnterActions>
+                                                <RemoveStoryboard BeginStoryboardName="fadeInM" />
+                                                <BeginStoryboard x:Name="fadeOutM" Storyboard="{StaticResource fadeOut}" />
+                                            </DataTrigger.EnterActions>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding Player.Activity.Mode}" Value="Active">
+                                            <DataTrigger.EnterActions>
+                                                <RemoveStoryboard BeginStoryboardName="fadeInM" />
+                                                <BeginStoryboard x:Name="fadeOutM2" Storyboard="{StaticResource fadeOut}" />
+                                            </DataTrigger.EnterActions>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding Player.Activity.Mode, FallbackValue=FullActive, TargetNullValue=FullActive}" Value="FullActive">
+                                            <DataTrigger.EnterActions>
+                                                <RemoveStoryboard BeginStoryboardName="fadeOutM" />
+                                                <RemoveStoryboard BeginStoryboardName="fadeOutM2" />
+                                                <BeginStoryboard x:Name="fadeInM" Storyboard="{StaticResource fadeIn}" />
+                                            </DataTrigger.EnterActions>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Grid.Style>
+
+                            <!--SlideShow ToolBar (Play|Pause, Restart, Settings)-->
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Center" Margin="0 60 0 0">
+                                <StackPanel.Background>
+                                    <SolidColorBrush Color="{Binding Player.Config.Video.BackgroundColor}" Opacity="0.35"/>
+                                </StackPanel.Background>
+                                <Button Command="{Binding Tag.SlideShowToggle}" IsEnabled="{Binding Tag.CanNextImage}" Focusable="False" Foreground="White">
+                                    <Button.Style>
+                                        <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignIconButton}">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                            <Setter Property="Content" Value="{materialDesign:PackIcon Kind=Play,Size=34}"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Tag.SlideShow}" Value="True">
+                                                    <Setter Property="Content" Value="{materialDesign:PackIcon Kind=Pause,Size=34}"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Button.Style>
+                                </Button>
+                                <Button Style="{StaticResource MaterialDesignIconButton}" Content="{materialDesign:PackIcon Kind=Restart,Size=34}" Command="{Binding Tag.SlideShowRestart}" IsEnabled="{Binding Tag.CanPrevImage}" Focusable="False" Foreground="White">
+                                    <Button.Background>
+                                        <SolidColorBrush Color="{Binding Player.Config.Video.BackgroundColor}" Opacity="0.35"/>
+                                    </Button.Background>
+                                </Button>
+                                <Button Style="{StaticResource MaterialDesignIconButton}" Content="{materialDesign:PackIcon Kind=GearOutline,Size=34}" Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}" Focusable="False" Foreground="White">
+                                    <Button.CommandParameter>
+                                        <Border BorderThickness="1" BorderBrush="{DynamicResource MaterialDesign.Brush.Primary}">
+                                            <StackPanel Margin="20 10 20 8">
+                                                <StackPanel Orientation="Horizontal" Margin="0 0 0 8">
+                                                    <TextBlock Width="140" Text="Timer (ms): " VerticalAlignment="Center" Margin="0 0 4 0"/>
+                                                    <TextBox Text="{Binding Tag.SlideShowTimer}" TextAlignment="Left"/>
+                                                </StackPanel>
+                                                <StackPanel Orientation="Horizontal" Margin="0 0 0 8">
+                                                    <TextBlock Width="140" Text="Page Step: " VerticalAlignment="Center" Margin="0 0 4 0"/>
+                                                    <TextBox Text="{Binding Tag.PageStep}" TextAlignment="Left"/>
+                                                </StackPanel>
+                                                <StackPanel Orientation="Horizontal" Margin="0 0 0 8">
+                                                    <TextBlock Width="140" Text="Max Images: " VerticalAlignment="Center" Margin="0 0 4 0"/>
+                                                    <TextBox Text="{Binding Tag.MaxFiles}" TextAlignment="Left"/>
+                                                </StackPanel>
+                                                <StackPanel Orientation="Horizontal" Margin="0 0 0 16">
+                                                    <TextBlock Width="140" Text="Delete Confirmation: " VerticalAlignment="Center" Margin="0 0 4 0"/>
+                                                    <ToggleButton IsChecked="{Binding Tag.DeleteConfirmation}"/>
+                                                </StackPanel>
+                                                <Button HorizontalAlignment="Center" Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}" CommandParameter="Sample2Cancel" Content="Save" IsCancel="True"/>
+                                            </StackPanel>
+                                        </Border>
+                                    </Button.CommandParameter>
+                                </Button>
+                            </StackPanel>
+
+                            <!--Show Prev Arrow Button-->
+                            <Button Style="{StaticResource MaterialDesignOutlinedSecondaryButton}" Command="{Binding Tag.ShowPrevImage}" IsEnabled="{Binding Tag.CanPrevImage}" Focusable="False" Content="{materialDesign:PackIcon Kind=ArrowLeft,Size=30}" Padding="0" Margin="0" VerticalContentAlignment="Center" Width="40" Height="100" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+
+                            <!--Show Prev Next Button-->
+                            <Button Style="{StaticResource MaterialDesignOutlinedSecondaryButton}" Command="{Binding Tag.ShowNextImage}" IsEnabled="{Binding Tag.CanNextImage}" Focusable="False" Content="{materialDesign:PackIcon Kind=ArrowRight,Size=30}" Padding="0" Margin="0" VerticalContentAlignment="Center" Width="40" Height="100" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+
+                            <!--Index / Total-->
+                            <TextBlock VerticalAlignment="Bottom" HorizontalAlignment="Right" d:Text="526 / 1000" FontWeight="Bold" FontSize="14" Margin="20" Foreground="{DynamicResource MaterialDesign.Brush.Secondary}">
+                                <TextBlock.Text>
+                                    <MultiBinding StringFormat="{}{0} / {1}">
+                                        <Binding Path="Tag.UIImageIndex" />
+                                        <Binding Path="Tag.TotalFiles" />
+                                    </MultiBinding>
+                                </TextBlock.Text>
+                            </TextBlock>
+                        </Grid>
+                    </materialDesign:DialogHost>
                     
-                    <TextBlock VerticalAlignment="Top" HorizontalAlignment="Right" Padding="4" Margin="0 -40 10 0" FontWeight="Bold" d:Text="Playing" FontSize="18" Text="{Binding Player.Status}" Foreground="{DynamicResource MaterialDesign.Brush.Secondary}">
-                        <TextBlock.Background>
-                            <SolidColorBrush Color="{Binding Player.Config.Video.BackgroundColor}" Opacity="0.15"/>
-                        </TextBlock.Background>
-                        <TextBlock.Style>
-                            <Style TargetType="{x:Type TextBlock}">
-                                <Setter Property="Visibility" Value="Collapsed"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Player.Activity.Mode}" Value="Active" d:Value="{x:Null}">
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
+                    <!-- (All Views) -->
                     
+                    <!--Debug Info-->
+                    <fl:PlayerDebug Grid.Row="0" Grid.RowSpan="2" VerticalAlignment="Center" HorizontalAlignment="Center" Player="{Binding Player}" BoxColor="#AA000000" HeaderColor="White" InfoColor="{DynamicResource MaterialDesign.Brush.Primary.Light}" ValueColor="{DynamicResource MaterialDesign.Brush.Secondary.Light}" Visibility="{Binding ShowDebug, Converter={StaticResource BooleanToVisibility}, FallbackValue=Collapsed, TargetNullValue=Collapsed}"/>
+                
                     <!--Error Message-->
-                    <TextBox VerticalAlignment="Center" HorizontalAlignment="Center" Margin="10" d:Text="Error Message" FontSize="16" IsReadOnly="True" BorderThickness="0" Text="{Binding Player.LastError}" Foreground="{DynamicResource MaterialDesign.Brush.Primary}" TextWrapping="Wrap">
+                    <TextBox Grid.Row="0" Grid.RowSpan="2" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="10" d:Text="Error Message" FontSize="16" IsReadOnly="True" BorderThickness="0" Text="{Binding Player.LastError}" Foreground="{DynamicResource MaterialDesign.Brush.Primary}" TextWrapping="Wrap">
                         <TextBox.Background>
                             <SolidColorBrush Color="{Binding Player.Config.Video.BackgroundColor}" Opacity="0.15"/>
                         </TextBox.Background>
@@ -202,32 +362,6 @@
                         </TextBox.Style>
                     </TextBox>
                     
-                    <!--Pop Up Dialog (Settings/Set Values)-->
-                    <materialDesign:DialogHost x:Name="PART_DialogSettings" OverlayBackground="{x:Null}"/>
-
-                    <!--Debug Info-->
-                    <fl:PlayerDebug VerticalAlignment="Center" HorizontalAlignment="Center" Player="{Binding Player}" BoxColor="#AA000000" HeaderColor="White" InfoColor="{DynamicResource MaterialDesign.Brush.Primary.Light}" ValueColor="{DynamicResource MaterialDesign.Brush.Secondary.Light}" Visibility="{Binding ShowDebug, Converter={StaticResource BooleanToVisibility}, FallbackValue=Collapsed, TargetNullValue=Collapsed}"/>
-
-                    <!--Subtitles-->
-                    <flwpf:OutlinedTextBlock Stroke="{Binding Player.Config.Video.BackgroundColor, Converter={StaticResource ColorToBrush}}" 
-                         ClipToBounds="False"
-                         Fill="{Binding UIConfig.SubsFontColor, Converter={StaticResource ColorToBrush}}"
-                         StrokePosition="Outside"
-                         StrokeThicknessInitial="{Binding UIConfig.SubsStrokeThickness}"
-                         Margin="{Binding UIConfig.SubsMargin2}"
-                         VerticalAlignment="Bottom"
-                         HorizontalAlignment="Center"
-                         TextAlignment="Center"
-                         TextWrapping="Wrap"
-                         FontFamily="{Binding UIConfig.SubsFontFamily}"
-                         FontSizeInitial="{Binding UIConfig.SubsFontSize}"
-                         FontWeight="{Binding UIConfig.SubsFontWeight}"
-                         FontStyle="{Binding UIConfig.SubsFontStyle}"
-                         Text="{Binding Player.Subtitles.SubsText}">
-                    </flwpf:OutlinedTextBlock>
-
-                    <!--Flyleaf Bar-->
-                    <flwpf:FlyleafBar Player="{Binding Player}" Margin="-2 0 -2 0"/>
                 </Grid>
             </Grid>
         </Border>

--- a/Samples/FlyleafPlayer (WPF Control) (WPF)/MainWindow.xaml.cs
+++ b/Samples/FlyleafPlayer (WPF Control) (WPF)/MainWindow.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -21,8 +23,8 @@ namespace FlyleafPlayer
     /// </summary>
     public partial class MainWindow : Window, INotifyPropertyChanged
     {
-        const int ACTIVITY_TIMEOUT = 3500;
         public event PropertyChangedEventHandler PropertyChanged;
+        public void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new(propertyName));
         public static string FlyleafLibVer => "FlyleafLib v" + System.Reflection.Assembly.GetAssembly(typeof(Engine)).GetName().Version;
         
         /// <summary>
@@ -37,20 +39,24 @@ namespace FlyleafPlayer
 
         public ICommand     OpenWindow  { get; set; }
         public ICommand     CloseWindow { get; set; }
-
+        
         static bool runOnce;
         Config playerConfig;
         bool ReversePlaybackChecked;
-        
+
         public MainWindow()
         {
-            OpenWindow  = new RelayCommandSimple(() => new MainWindow() { Width = Width, Height = Height }.Show());
-            CloseWindow = new RelayCommandSimple(Close);
+            OpenWindow      = new RelayCommandSimple(() => new MainWindow() { Width = Width, Height = Height }.Show());
+            CloseWindow     = new RelayCommandSimple(Close);
+            ShowPrevImage   = new RelayCommandSimple(() => SlideShowGoTo(ImageIndex - 1));
+            ShowNextImage   = new RelayCommandSimple(() => SlideShowGoTo(ImageIndex + 1));
+            SlideShowToggle = new RelayCommandSimple(SlideShowToggleAction);
+            SlideShowRestart= new RelayCommandSimple(() => { SlideShowStart(false, false); SlideShowGoTo(0); }); // Note: When we start SlideShow with non-current ImageIndex use Start(notask) and GoTo to start the task
 
             FlyleafME = new FlyleafME(this)
             {
                 Tag = this,
-                ActivityTimeout     = ACTIVITY_TIMEOUT,
+                ActivityTimeout     = MSG_TIMEOUT,
                 KeyBindings         = AvailableWindows.Both,
                 DetachedResize      = AvailableWindows.Overlay,
                 DetachedDragMove    = AvailableWindows.Both,
@@ -110,12 +116,15 @@ namespace FlyleafPlayer
               ////new() { Name ="rubberband", Args="pitch=1.5" }
             //};
             #endif
-
+            
             // Initializes the Player
             Player = new Player(playerConfig);
 
             // Dispose Player on Window Close (the possible swapped player from FlyleafMe that actually belongs to us)
             Closing += (o, e) => FlyleafME.Player?.Dispose();
+
+            Player.Opening      += Player_Opening;
+            Player.OpenCompleted+= Player_OpenCompleted;
 
             // If the user requests reverse playback allocate more frames once
             Player.PropertyChanged += (o, e) =>
@@ -135,7 +144,6 @@ namespace FlyleafPlayer
                     GetWindowFromPlayer(Player).Msg = $"Zoom {Player.Zoom}%";
                 else if (e.PropertyName == nameof(Player.Status) && Player.Activity.Mode == ActivityMode.Idle)
                     Player.Activity.ForceActive();
-
             };
 
             Player.Audio.PropertyChanged += (o, e) =>
@@ -159,17 +167,16 @@ namespace FlyleafPlayer
             };
 
             // Ctrl+ N / Ctrl + W (Open New/Close Window)
-            var key = playerConfig.Player.KeyBindings.Get("New Window");
-            if (key != null)
-                key.SetAction(() => (new MainWindow()).Show(), true);
-            else
-                playerConfig.Player.KeyBindings.AddCustom(Key.N, true, () => CreateNewWindow(Player), "New Window", false, true, false);
-
-            key = playerConfig.Player.KeyBindings.Get("Close Window");
-            if (key != null)
-                key.SetAction(() => Close(), true);
-            else
-                playerConfig.Player.KeyBindings.AddCustom(Key.W, true, () => GetWindowFromPlayer(Player).Close(), "Close Window", false, true, false);
+            var keys = playerConfig.Player.KeyBindings;
+            keys.AddCustom(Key.N, true, () => CreateNewWindow(Player), "New Window", false, true, false);
+            keys.AddCustom(Key.W, true, () => GetWindowFromPlayer(Player).Close(), "Close Window", false, true, false);
+            
+            // We might saved the tmp keys (restore them)
+            if (Player.Config.Loaded && keys.Exists("tmp01"))
+            {
+                SlideKeysRemove();
+                VideoKeysRestore();
+            }
         }
 
         private static MainWindow GetWindowFromPlayer(Player player)
@@ -249,15 +256,493 @@ namespace FlyleafPlayer
         private void BtnMinimize_Click(object sender, RoutedEventArgs e) => FlyleafME.IsMinimized = true;
         private void BtnClose_Click(object sender, RoutedEventArgs e) => Close();
 
+        #region Photo Viewer / Slide Show
+        /* TODO
+         * Sorting (+based on explorer folder settings / numerical*)
+         * Shuffle
+         * Include / Exclude  (SubFolder/Image/Animation/Video *Regex)
+         * Prepare next? (for faster/better transition)
+         * Preview Film/Slider/Gallery?
+         * Config / Keys** Save?
+         */
+
+        #region Slide Show Config
+        public int          SlideShowTimer      { get => slideShowTimer;        set { if (slideShowTimer == value) return;      slideShowTimer = value;     OnPropertyChanged(nameof(SlideShowTimer)); } }
+        int slideShowTimer = 3000;
+        public int          PageStep            { get => pageStep;              set { if (pageStep == value) return;            pageStep = value;           OnPropertyChanged(nameof(PageStep)); } }
+        int pageStep = 10;
+        public int          MaxFiles            { get => maxFiles;              set { if (maxFiles == value) return;            maxFiles = value;           OnPropertyChanged(nameof(MaxFiles)); } }
+        int maxFiles = 5000;
+        public bool         DeleteConfirmation  { get => deleteConfirmation;    set { if (deleteConfirmation == value) return;  deleteConfirmation = value; OnPropertyChanged(nameof(DeleteConfirmation)); } }
+        bool deleteConfirmation = true;
+        #endregion
+
+        public ICommand     ShowNextImage   { get; set; }
+        public ICommand     ShowPrevImage   { get; set; }
+        public ICommand     SlideShowToggle { get; set; }
+        public ICommand     SlideShowRestart{ get; set; }
+
+        public bool         CanNextImage    { get => canNextImage;  set { if (canNextImage == value) return;    canNextImage = value;   Utils.UI(() => OnPropertyChanged(nameof(CanNextImage))); } }
+        bool canNextImage;
+
+        public bool         CanPrevImage    { get => canPrevImage;  set { if (canPrevImage == value) return;    canPrevImage = value;   Utils.UI(() => OnPropertyChanged(nameof(CanPrevImage))); } }
+        bool canPrevImage;
+
+        public MediaViewer  MediaViewer     { get => mediaViewer;   set { if (mediaViewer == value) return;     prevMediaViewer = mediaViewer; mediaViewer = value; SwitchMediaViewer(); Utils.UI(() => OnPropertyChanged(nameof(MediaViewer))); } }
+        MediaViewer mediaViewer = MediaViewer.Video; MediaViewer prevMediaViewer;
+
+        public string       ImageTitle      { get => imageTitle;    set { if (imageTitle == value) return;      imageTitle = value;     Utils.UI(() => OnPropertyChanged(nameof(ImageTitle))); } }
+        string imageTitle;
+
+        public FileInfo     ImageInfo       { get => imageInfo;     set { if (imageInfo == value) return;       imageInfo = value; ImageTitle = value?.Name; } }
+        FileInfo imageInfo;
+
+        public List<string> ImageFiles      { get; set; } = [];
+        public int          ImageIndex      { get => imageIndex;    set { if (imageIndex == value) return;      imageIndex = value; UIImageIndex = imageIndex + 1; Utils.UI(() => OnPropertyChanged(nameof(UIImageIndex))); } }
+        int imageIndex = -1;
+        public int          UIImageIndex    { get; set; }
+
+        public string       ImageFolder     { get => imageFolder;   set { prevImageFolder = imageFolder;        imageFolder = value; } }
+        string imageFolder, prevImageFolder;
+
+        public bool         SlideShow       { get => slideShow;     set { if (slideShow == value) return;       slideShow = value;      Utils.UI(() => OnPropertyChanged(nameof(SlideShow))); } }
+        bool slideShow;
+
+        public int          TotalFiles      { get => totalFiles;    set { if (totalFiles == value) return;      totalFiles = value;     Utils.UI(() => OnPropertyChanged(nameof(TotalFiles))); } }
+        int totalFiles;
+
+        CancellationTokenSource
+                            slideShowCancel = new();
+        object              slideShowLock   = new();
+        int                 slideShowElapsedMs;         // For Pause/Play to keep the remaining ms
+        long                slideShowStartedAt;         // For Pause/Play to keep the remaining ms
+        FileSystemWatcher   slideShowWatcher;           // Monitor ImageFolder for changes
+        bool                imageFilesChanged;
+        bool                userKeepRatioOnResize;
+
+        [GeneratedRegex("\\.(apng|avif|bmp|jpg|jpeg|gif|ico|png|svg|tiff|webp)$", RegexOptions.IgnoreCase, "en-US")]
+        private static partial Regex RegexImages();
+
+        void Player_Opening(object sender, OpeningArgs e)
+        {
+            if (e.IsSubtitles || e.Url == null)
+                return;
+
+            var url = e.Url;
+
+            if (!RegexImages().IsMatch(url))
+                MediaViewer = MediaViewer.Video;
+            else
+            {
+                try
+                {
+                    ImageInfo = new(url);
+                    ImageFolder = ImageInfo.Exists ? Path.GetDirectoryName(ImageInfo.FullName) : null;
+                    SlideShowCheck();
+                }
+                catch (Exception)
+                {
+                    if (ImageInfo == null)
+                        ImageTitle = url;
+
+                    ImageFolder = null;
+                    MediaViewer = MediaViewer.Image;
+                }
+            }
+        }
+        void Player_OpenCompleted(object sender, OpenCompletedArgs e)
+        {
+            if (e.IsSubtitles)
+                return;
+
+            lock (slideShowLock)
+                if (SlideShow)
+                {
+                    slideShowCancel.Cancel();
+                    slideShowCancel = new();
+                    slideShowStartedAt = DateTime.UtcNow.Ticks;
+                    slideShowElapsedMs = 0;
+                    Task.Run(SlideShowTask, slideShowCancel.Token);
+                }
+        }
+
+        void SwitchMediaViewer()
+        {
+            var keys = playerConfig.Player.KeyBindings;
+
+            switch (prevMediaViewer)
+            {
+                case MediaViewer.Video:
+                    userKeepRatioOnResize = FlyleafME.KeepRatioOnResize;
+                    break;
+
+                case MediaViewer.Image:
+                    break;
+
+                case MediaViewer.Slide:
+                    SlideShowDeInit();
+                    SlideKeysRemove();
+
+                    break;
+            }
+
+            switch (MediaViewer)
+            {
+                case MediaViewer.Video:
+                    ImageInfo = null;
+                    ImageFolder = null;
+
+                    FlyleafME.ToggleFullScreenOnDoubleClick = AvailableWindows.Both;
+                    FlyleafME.KeyBindings = AvailableWindows.Both;
+                    FlyleafME.KeepRatioOnResize = userKeepRatioOnResize;
+
+                    VideoKeysRestore();
+
+                    break;
+
+                case MediaViewer.Image:
+                    FlyleafME.ToggleFullScreenOnDoubleClick = AvailableWindows.Surface;
+                    FlyleafME.KeyBindings = AvailableWindows.Surface;
+                    FlyleafME.KeepRatioOnResize = userKeepRatioOnResize;
+
+                    break;
+
+                case MediaViewer.Slide:
+                    FlyleafME.ToggleFullScreenOnDoubleClick = AvailableWindows.Surface;
+                    FlyleafME.KeyBindings = AvailableWindows.Surface;
+                    FlyleafME.KeepRatioOnResize = false;
+
+                    SlideKeysAdd();
+                    break;
+            }
+        }
+
+        void SlideShowCheck()
+        {
+            if (prevImageFolder == imageFolder)
+            {
+                if (imageFolder == null)
+                    MediaViewer = MediaViewer.Image;
+                else if (MediaViewer != MediaViewer.Slide)
+                    return;
+                else if (ImageFiles[ImageIndex] != ImageInfo.FullName)
+                {
+                    int foundIndex = -1;
+
+                    for (int i = 0; i < ImageFiles.Count; i++)
+                        if (ImageFiles[i] == ImageInfo.FullName)
+                            { foundIndex = i; break; }
+
+                    if (foundIndex == -1)
+                        MediaViewer = MediaViewer.Image; // Maybe recalculate files?
+                    else
+                    {
+                        if (SlideShow)
+                        {
+                            slideShowCancel.Cancel();
+                            slideShowCancel = new();
+                        }
+
+                        ImageIndex = foundIndex;
+                        CanPrevImage = ImageIndex > 0;
+                        CanNextImage = ImageIndex < ImageFiles.Count - 1;
+
+                        if (SlideShow && !CanNextImage)
+                            SlideShow = false;
+                    }
+                }
+            }
+            else if (imageFolder == null)
+                MediaViewer = MediaViewer.Image;
+            else
+            {
+                var files = Directory.GetFiles(imageFolder, $"*.*");
+                if (files.Length < 2)
+                    MediaViewer = MediaViewer.Image;
+                else
+                {
+                    List<string> imagefiles = [];
+                    int imageIndex = -1;
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        var file = files[i];
+                        if (!RegexImages().IsMatch(file))
+                            continue;
+
+                        if (file.Equals(imageInfo.FullName, StringComparison.OrdinalIgnoreCase))
+                            imageIndex = imagefiles.Count;
+
+                        imagefiles.Add(file);
+                        if (imagefiles.Count > maxFiles)
+                            break;
+                    }
+
+                    if (imagefiles.Count < 2)
+                        MediaViewer = MediaViewer.Image;
+                    else
+                    {
+                        lock (slideShowLock)
+                        {
+                            slideShowWatcher = new(imageFolder);
+                            slideShowWatcher.EnableRaisingEvents = true;
+                            slideShowWatcher.NotifyFilter = NotifyFilters.FileName;
+                            
+                            slideShowWatcher.Renamed += (o, e) =>
+                            {
+                                if (!imageFilesChanged && RegexImages().IsMatch(e.Name))
+                                    imageFilesChanged = true;
+                            };
+
+                            slideShowWatcher.Deleted += (o, e) =>
+                            {
+                                if (!imageFilesChanged && RegexImages().IsMatch(e.Name))
+                                    imageFilesChanged = true;
+                            };
+
+                            slideShowWatcher.Created += (o, e) =>
+                            {
+                                if (!imageFilesChanged && RegexImages().IsMatch(e.Name))
+                                    imageFilesChanged = true;
+                            };
+
+                            slideShowCancel.Cancel();
+                            slideShowCancel = new();
+
+                            ImageFiles  = imagefiles;
+                            TotalFiles  = imagefiles.Count;
+                            ImageIndex  = imageIndex == -1 ? 0 : imageIndex;
+                            CanPrevImage= ImageIndex > 0;
+                            CanNextImage= ImageIndex < ImageFiles.Count - 1;
+                            MediaViewer = MediaViewer.Slide;
+                        }
+                    }
+                }
+            }
+        }
+        void SlideShowReCheck(ref int index)
+        {
+            if (!imageFilesChanged)
+                return;
+
+            imageFilesChanged = false;
+
+            var files = Directory.GetFiles(imageFolder, $"*.*");
+            if (files.Length < 2)
+                MediaViewer = MediaViewer.Image;
+            else
+            {
+                List<string> imagefiles = [];
+                int imageIndex = -1;
+                for (int i = 0; i < files.Length; i++)
+                {
+                    var file = files[i];
+                    if (!RegexImages().IsMatch(file))
+                        continue;
+
+                    if (file.Equals(imageInfo.FullName, StringComparison.OrdinalIgnoreCase))
+                        imageIndex = imagefiles.Count;
+
+                    imagefiles.Add(file);
+                    if (imagefiles.Count > maxFiles)
+                        break;
+                }
+
+                if (imagefiles.Count < 2)
+                    MediaViewer = MediaViewer.Image;
+                else
+                {
+                    if (index == 0)
+                        index = 0;
+                    else if (index == ImageFiles.Count - 1)
+                        index = imagefiles.Count - 1;
+                    else if (imageIndex != -1)
+                    {
+                        if (index - ImageIndex == 1)
+                            index = imageIndex + 1;
+                        else if (ImageIndex - index == 1)
+                            index = imageIndex - 1;
+                    }
+                    else if (index > imagefiles.Count - 1)
+                        index = imagefiles.Count - 1;
+
+                    ImageFiles = imagefiles;
+                    TotalFiles = imagefiles.Count;
+                }
+            }
+        }
+        void SlideShowDeInit()
+        {
+            lock (slideShowLock)
+            {
+                slideShowCancel.Cancel();
+                slideShowCancel = new();
+                ImageFiles.Clear();
+                ImageIndex = -1;
+                TotalFiles = 0;
+                slideShowElapsedMs = 0;
+                SlideShow = CanPrevImage = CanNextImage = false;
+                slideShowWatcher.Dispose();
+            }
+        }
+        void SlideShowGoTo(int index, bool fromSlideShow = false, bool restart = false)
+        {
+            lock (slideShowLock)
+            {
+                SlideShowReCheck(ref index);
+
+                if (MediaViewer != MediaViewer.Slide || index < 0 || index > ImageFiles.Count - 1)
+                    return;
+
+                if (SlideShow && !fromSlideShow)
+                {
+                    slideShowCancel.Cancel();
+                    slideShowCancel = new();
+                }                
+                
+                ImageIndex = index;
+                CanPrevImage = ImageIndex > 0;
+                CanNextImage = ImageIndex < ImageFiles.Count - 1;
+
+                if (SlideShow && !CanNextImage)
+                    SlideShow = false;
+
+                slideShowElapsedMs = 0;
+                Player.OpenAsync(ImageFiles[ImageIndex]);
+            }
+        }
+        void SlideShowStop()
+        {
+            lock (slideShowLock)
+            {
+                slideShowCancel.Cancel();
+                slideShowCancel = new();
+                SlideShow = false;
+                slideShowElapsedMs += (int) (DateTime.UtcNow.Ticks - slideShowStartedAt) / 10000;
+            }
+        }
+        void SlideShowStart(bool inFullScreen = false, bool andTask = true)
+        {
+            lock (slideShowLock)
+            {
+                slideShowCancel.Cancel();
+                slideShowCancel = new();
+                SlideShow = true;
+                if (inFullScreen)
+                    Player.FullScreen();
+
+                Player.Activity.ForceIdle();
+                if (andTask)
+                {
+                    slideShowStartedAt = DateTime.UtcNow.Ticks;
+                    Task.Run(SlideShowTask, slideShowCancel.Token);
+                }
+            }
+        }
+        void SlideShowToggleAction()
+        {
+            if (SlideShow)
+                SlideShowStop();
+            else if (canNextImage)
+                SlideShowStart();
+        }
+
+        async Task SlideShowTask()
+        {
+            if (Player.CanPlay && slideShowElapsedMs < slideShowTimer)
+                await Task.Delay(SlideShowTimer - slideShowElapsedMs, slideShowCancel.Token);
+
+            while (Player.IsPlaying)
+                await Task.Delay(100, slideShowCancel.Token);
+
+            if (slideShowCancel.IsCancellationRequested || !SlideShow)
+                return;
+
+            SlideShowGoTo(ImageIndex + 1, true);
+        }
+
+        void SlideKeysRemove()
+        {
+            var keys = playerConfig.Player.KeyBindings;
+
+            keys.Remove(Key.Left);
+            keys.Remove(Key.Right);
+            keys.Remove(Key.Home);
+            keys.Remove(Key.End);
+            keys.Remove(Key.Space);
+            keys.Remove(Key.F5);
+            keys.Remove(Key.Delete);
+            keys.Remove(Key.C, false, true);
+            keys.Remove(Key.X, false, true);
+            keys.Remove(Key.PageDown);
+            keys.Remove(Key.PageUp);
+        }
+        void SlideKeysAdd()
+        {
+            var keys = playerConfig.Player.KeyBindings;
+            keys.AddCustom(Key.Left,    false,  () => SlideShowGoTo(ImageIndex - 1), "tmp01");
+            keys.AddCustom(Key.Right,   false,  () => SlideShowGoTo(ImageIndex + 1), "tmp02");
+            keys.AddCustom(Key.Home,    true,   () => SlideShowGoTo(0), "tmp03");
+            keys.AddCustom(Key.End,     true,   () => SlideShowGoTo(ImageFiles.Count -1), "tmp04");
+            keys.AddCustom(Key.Space,   true,   SlideShowToggleAction, "tmp05");
+            keys.AddCustom(Key.F5,      true,   () => SlideShowStart(true), "tmp06");
+            keys.AddCustom(Key.Delete,  true,   ImageDelete, "tmp07");
+            keys.AddCustom(Key.C,       true,   () => ImageCutCopy(), "tmp08", false, true, false);
+            keys.AddCustom(Key.X,       true,   () => ImageCutCopy(false), "tmp09", false, true, false);
+            keys.AddCustom(Key.PageDown,false,  () => SlideShowGoTo(Math.Min(ImageFiles.Count - 1, ImageIndex + PageStep)), "tmp10");
+            keys.AddCustom(Key.PageUp,  false,  () => SlideShowGoTo(Math.Max(0, ImageIndex - PageStep)), "tmp11");
+        }
+        void VideoKeysRestore()
+        {
+            var keys = playerConfig.Player.KeyBindings;
+            keys.Add(Key.Left,  KeyBindingAction.SeekBackward);
+            keys.Add(Key.Right, KeyBindingAction.SeekForward);
+            keys.Add(Key.Space, KeyBindingAction.TogglePlayPause);
+            keys.Add(Key.C,     KeyBindingAction.CopyToClipboard, false, true);
+        }
+        void ImageDelete()
+        {
+            if (deleteConfirmation && MessageBox.Show("Are you sure to delete this image?", "Delete Confirmation", MessageBoxButton.YesNo) != MessageBoxResult.Yes)
+                return;
+            
+            Player.Stop();
+            try { File.Delete(ImageInfo.FullName); imageFilesChanged = true; } catch(Exception) { return; }
+            SlideShowGoTo(ImageIndex); //canNextImage ? ImageIndex + 1 : (canPrevImage ? ImageIndex - 1 : 0));
+        }
+        void ImageCutCopy(bool copy = true)
+        {
+            try
+            {
+                var droplist = new System.Collections.Specialized.StringCollection { imageInfo.FullName };
+                var data = new DataObject();
+                data.SetFileDropList(droplist);
+                data.SetData("Preferred DropEffect", new MemoryStream(copy ? DragDropEffectsCopyBytes : DragDropEffectsMoveBytes));
+                Clipboard.SetDataObject(data);
+
+                if (!copy) // This way we close the image so it can be paste (not great for the viewer)* similar to deleting a file when is already opened (ideally we close the input and we keep only the frame)
+                    SlideShowGoTo(canNextImage ? ImageIndex + 1 : (canPrevImage ? ImageIndex - 1 : 0));
+            } catch (Exception) {}
+        }
+        static byte[] DragDropEffectsCopyBytes = BitConverter.GetBytes((int)DragDropEffects.Copy);
+        static byte[] DragDropEffectsMoveBytes = BitConverter.GetBytes((int)DragDropEffects.Move);
+        #endregion
+
         #region OSD Msg
+        const int MSG_TIMEOUT = 3500;
         CancellationTokenSource cancelMsgToken = new();
-        public string Msg { get => msg; set { cancelMsgToken.Cancel(); msg = value; PropertyChanged?.Invoke(this, new(nameof(Msg))); cancelMsgToken = new(); Task.Run(FadeOutMsg, cancelMsgToken.Token); } }
+        public string Msg { get => msg; set { cancelMsgToken.Cancel(); msg = value; OnPropertyChanged(nameof(Msg)); cancelMsgToken = new(); Task.Run(FadeOutMsg, cancelMsgToken.Token); } }
         string msg;
         private async Task FadeOutMsg()
         {
-            await Task.Delay(ACTIVITY_TIMEOUT, cancelMsgToken.Token);
+            await Task.Delay(MSG_TIMEOUT, cancelMsgToken.Token);
             Utils.UIInvoke(() => { msg = ""; PropertyChanged?.Invoke(this, new(nameof(Msg))); });
         }
         #endregion
+    }
+
+    public enum MediaViewer
+    {
+        Image,
+        Video,
+        Slide
     }
 }


### PR DESCRIPTION
- Renderer: Fixes an access violation with broken files [Fixes #424]
- Subtitles: Prevents Local/Online Search for 'small' duration videos (less than 25 minutes)
- VideoDecoder: Fixes (possible) an issue with the codec's announced rotation
- Player.Keys: Allows overwriting existing keys instead of throwing an exception
- Player: Introduces Opening event
- FlyleafHost.Wpf: Activates Surface/Overlay window after DragNDrop
- PlayerDebug: Adds full Url
- Samples.FlyleafPlayer: Adds Photo Viewer / Slide Show support