### PR TITLE
Fix video changing on network stream not updating player to correct width/height

### DIFF
--- a/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
@@ -540,6 +540,12 @@ public unsafe class VideoDecoder : DecoderBase
                     ret = avcodec_receive_frame(codecCtx, frame);
                     if (ret != 0) { av_frame_unref(frame); break; }
 
+                    if (frame->height != VideoStream.Height || frame->width != VideoStream.Width)
+                    {
+                        // Resolution changed, refresh VideoStream from codec
+                        filledFromCodec = false;
+                    }
+
                     if (frame->best_effort_timestamp != AV_NOPTS_VALUE)
                         frame->pts = frame->best_effort_timestamp;
 


### PR DESCRIPTION
When playing network streams, if the video changes the player does not update width/height.
This change checks when receiving frame from decoder if width or height has changed.

How to test:
1. Start a network stream, e.g.: `ffmpeg -re -i my_test_video.ts -c copy -f mpegts udp://238.255.255.255:1234`
2. Start playback with the url
3. After the player has started playing run `taskkill -f -im ffmpeg.exe && ffmpeg -re -i my_other_test_video.ts -c copy -f mpegts udp://238.255.255.255:1234`
This assumes the two videos has different resolutions