### PR TITLE
fix: Infinite sleep occurs only for some rtsp videos

### DIFF
--- a/FlyleafLib/MediaPlayer/Player.Screamers.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.cs
@@ -395,7 +395,7 @@ unsafe partial class Player
                 : int.MaxValue;
 
             sleepMs = Math.Min(vDistanceMs, aDistanceMs) - 1;
-            if (sleepMs < 0)
+            if (sleepMs < 0 || sleepMs == int.MaxValue)
                 sleepMs = 0;
 
             if (sleepMs > 2)


### PR DESCRIPTION
fix: Infinite sleep occurs only for some rtsp videos