### PR TITLE
Specify maximum output framerate

### DIFF
--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -612,6 +612,11 @@ public class Config : NotifyPropertyChanged
         internal void SetEnabled(bool enabled)              => Set(ref _Enabled, enabled, true, nameof(Enabled));
 
         /// <summary>
+        /// Used to limit the number of frames rendered, particularly at increased speed
+        /// </summary>
+        public int              MaxOutputFps                { get; set; } = 30;
+
+        /// <summary>
         /// The max resolution that the current system can achieve and will be used from the input/stream suggester plugins
         /// </summary>
         [XmlIgnore]

--- a/FlyleafLib/MediaFramework/MediaDecoder/DecoderBase.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/DecoderBase.cs
@@ -190,7 +190,7 @@ public abstract unsafe class DecoderBase : RunThreadBase
             demuxer         = null;
             Stream          = null;
             Status          = Status.Stopped;
-            curSpeedFrame   = 1;
+            curSpeedFrame   = (int)speed;
             Disposed        = true;
             Log.Info("Disposed");
         }

--- a/FlyleafLib/MediaFramework/MediaDecoder/DecoderBase.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/DecoderBase.cs
@@ -23,7 +23,7 @@ public abstract unsafe class DecoderBase : RunThreadBase
     protected virtual void OnSpeedChanged(double value) { }
 
     internal bool               filledFromCodec;
-    protected int               framesSinceFlush= 0;
+    protected int               curSpeedFrame = 1;
     protected AVFrame*          frame;
     protected AVCodecContext*   codecCtx;
     internal  object            lockCodecCtx    = new();
@@ -190,7 +190,7 @@ public abstract unsafe class DecoderBase : RunThreadBase
             demuxer         = null;
             Stream          = null;
             Status          = Status.Stopped;
-            framesSinceFlush= 0;
+            curSpeedFrame   = 1;
             Disposed        = true;
             Log.Info("Disposed");
         }

--- a/FlyleafLib/MediaFramework/MediaDecoder/DecoderBase.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/DecoderBase.cs
@@ -23,7 +23,7 @@ public abstract unsafe class DecoderBase : RunThreadBase
     protected virtual void OnSpeedChanged(double value) { }
 
     internal bool               filledFromCodec;
-    protected int               curSpeedFrame = 1;
+    protected int               framesSinceFlush= 0;
     protected AVFrame*          frame;
     protected AVCodecContext*   codecCtx;
     internal  object            lockCodecCtx    = new();
@@ -190,7 +190,7 @@ public abstract unsafe class DecoderBase : RunThreadBase
             demuxer         = null;
             Stream          = null;
             Status          = Status.Stopped;
-            curSpeedFrame   = (int)speed;
+            framesSinceFlush= 0;
             Disposed        = true;
             Log.Info("Disposed");
         }

--- a/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
@@ -377,7 +377,7 @@ public unsafe class VideoDecoder : DecoderBase
                 keyFoundWithNoPts
                                 = false;
                 StartTime       = AV_NOPTS_VALUE;
-                framesSinceFlush= 0;
+                curSpeedFrame   = (int)speed;
             }
     }
 
@@ -537,7 +537,6 @@ public unsafe class VideoDecoder : DecoderBase
                 
                 while (true)
                 {
-                    framesSinceFlush++;
                     ret = avcodec_receive_frame(codecCtx, frame);
                     if (ret != 0) { av_frame_unref(frame); break; }
 
@@ -597,12 +596,14 @@ public unsafe class VideoDecoder : DecoderBase
                     double inputRate = speed * VideoStream.FPS;
                     if (inputRate > Config.Video.MaxOutputFps)
                     {
+                        curSpeedFrame++;
                         double inputOutputRatio = inputRate / Config.Video.MaxOutputFps;
-                        if (framesSinceFlush % inputOutputRatio > 1)
+                        if (curSpeedFrame < inputOutputRatio)
                         {
                             av_frame_unref(frame);
                             continue;
                         }
+                        curSpeedFrame = 0;
                     }
 
                     var mFrame = Renderer.FillPlanes(frame);


### PR DESCRIPTION
- Added MaxOutputFps to video options
- Changed to counting frames since the last flush to drop frames when the input rate (Speed * FPS) is greater than the specified MaxOuputFPS

Addresses issue I brought up here: [Overriding output frame rate](https://github.com/SuRGeoNix/Flyleaf/issues/323)