### PR TITLE
PR local

### DIFF
--- a/FlyleafLib/MediaFramework/MediaContext/DecoderContext.Open.cs
+++ b/FlyleafLib/MediaFramework/MediaContext/DecoderContext.Open.cs
@@ -769,7 +769,7 @@ public partial class DecoderContext
             error = Open(stream, defaultAudio).Error;
         else if (extStream != null)
             error = Open(extStream, defaultAudio).Error;
-        else if (defaultAudio)
+        else if (defaultAudio && Config.Audio.Enabled)
             error = OpenSuggestedAudio(); // We still need audio if no video exists
 
         return error;

--- a/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
@@ -646,7 +646,7 @@ public unsafe class VideoDecoder : DecoderBase
             avcodec_parameters_from_context(Stream.AVStream->codecpar, codecCtx);
             VideoStream.AVStream->time_base = codecCtx->pkt_timebase;
             VideoStream.Refresh(codecCtx->sw_pix_fmt != AVPixelFormat.AV_PIX_FMT_NONE ? codecCtx->sw_pix_fmt : codecCtx->pix_fmt, frame);
-
+            
             if (!(VideoStream.FPS > 0)) // NaN
             {
                 VideoStream.FPS             = av_q2d(codecCtx->framerate) > 0 ? av_q2d(codecCtx->framerate) : 0;
@@ -658,7 +658,7 @@ public unsafe class VideoDecoder : DecoderBase
             skipSpeedFrames = speed * VideoStream.FPS / Config.Video.MaxOutputFps;
             CodecChanged?.Invoke(this);
 
-            if (!Renderer.ConfigPlanes())
+            if (VideoStream.PixelFormat == AVPixelFormat.AV_PIX_FMT_NONE || !Renderer.ConfigPlanes())
             {
                 Log.Error("[Pixel Format] Unknown");
                 return -1234;

--- a/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
+++ b/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
@@ -551,7 +551,7 @@ public unsafe class Demuxer : RunThreadBase
             int queryStarts = url.IndexOf('?');
             if (queryStarts != -1)
             {
-                string query = Url[(queryStarts + 1)..];
+                string query = url[(queryStarts + 1)..];
                 var qp = HttpUtility.ParseQueryString(query);
                 url = url[..queryStarts] + "?";
 
@@ -700,7 +700,8 @@ public unsafe class Demuxer : RunThreadBase
                         if ((fmtCtx->streams[i]->disposition & AV_DISPOSITION_ATTACHED_PIC) != 0) 
                             { Log.Info($"Excluding image stream #{i}"); continue; }
 
-                        if (((AVPixelFormat)fmtCtx->streams[i]->codecpar->format) == AVPixelFormat.AV_PIX_FMT_NONE)
+                        // TBR: When AllowFindStreamInfo = false we can get valid pixel format during decoding (in case of remuxing only this might crash, possible check if usedecoders?)
+                        if (((AVPixelFormat)fmtCtx->streams[i]->codecpar->format) == AVPixelFormat.AV_PIX_FMT_NONE && Config.AllowFindStreamInfo)
                         {
                             Log.Info($"Excluding invalid video stream #{i}");
                             continue;


### PR DESCRIPTION
DecoderContext: Prevent opening audio stream when audio is disabled

Demuxer: Fixes an issue while passing HTTP Query Parameters

Demuxer: When AllowFindStreamInfo = false will allow video streams with unidentified pixel formats (will be identified during decoding)