### PR TITLE
Added custom drop events to wpf FlyleafHost

### DIFF
--- a/FlyleafLib/Controls/WPF/FlyleafHost.cs
+++ b/FlyleafLib/Controls/WPF/FlyleafHost.cs
@@ -102,6 +102,8 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
 
     public event EventHandler SurfaceCreated;
     public event EventHandler OverlayCreated;
+    public event DragEventHandler OnSurfaceDrop;
+    public event DragEventHandler OnOverlayDrop;
 
     static bool isDesginMode;
     static int  idGenerator = 1;
@@ -1116,19 +1118,25 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
         if (Player == null)
             return;
 
-        // Player Open File
-        if (e.Data.GetDataPresent(DataFormats.FileDrop))
-        {
-            string filename = ((string[])e.Data.GetData(DataFormats.FileDrop, false))[0];
-            Player.OpenAsync(filename);
-        }
+        // Invoke event first and see if it gets handled
+        OnSurfaceDrop?.Invoke(this, e);
 
-        // Player Open Text
-        else if (e.Data.GetDataPresent(DataFormats.Text))
+        if (!e.Handled)
         {
-            string text = e.Data.GetData(DataFormats.Text, false).ToString();
-            if (text.Length > 0)
-                Player.OpenAsync(text);
+            // Player Open File
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                string filename = ((string[])e.Data.GetData(DataFormats.FileDrop, false))[0];
+                Player.OpenAsync(filename);
+            }
+
+            // Player Open Text
+            else if (e.Data.GetDataPresent(DataFormats.Text))
+            {
+                string text = e.Data.GetData(DataFormats.Text, false).ToString();
+                if (text.Length > 0)
+                    Player.OpenAsync(text);
+            }
         }
 
         Surface.Activate();
@@ -1150,19 +1158,25 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
         if (Player == null)
             return;
 
-        // Player Open File
-        if (e.Data.GetDataPresent(DataFormats.FileDrop))
-        {
-            string filename = ((string[])e.Data.GetData(DataFormats.FileDrop, false))[0];
-            Player.OpenAsync(filename);
-        }
+        // Invoke event first and see if it gets handled
+        OnOverlayDrop?.Invoke(this, e);
 
-        // Player Open Text
-        else if (e.Data.GetDataPresent(DataFormats.Text))
+        if (!e.Handled)
         {
-            string text = e.Data.GetData(DataFormats.Text, false).ToString();
-            if (text.Length > 0)
-                Player.OpenAsync(text);
+            // Player Open File
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                string filename = ((string[])e.Data.GetData(DataFormats.FileDrop, false))[0];
+                Player.OpenAsync(filename);
+            }
+
+            // Player Open Text
+            else if (e.Data.GetDataPresent(DataFormats.Text))
+            {
+                string text = e.Data.GetData(DataFormats.Text, false).ToString();
+                if (text.Length > 0)
+                    Player.OpenAsync(text);
+            }
         }
 
         Overlay.Activate();


### PR DESCRIPTION
Added two new events to wpf FlyleafHost:
OnSurfaceDrop and OnOverlayDrop

These events will be invoked and checked if anything handled the event before trying to solve the events internally.

This will enable users to have custom handling of drop events (like viewmodels)