### PR TITLE
Fix DataDecoder null ref on demuxer when disposing player

### DIFF
--- a/FlyleafLib/MediaFramework/MediaDecoder/DataDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/DataDecoder.cs
@@ -116,6 +116,8 @@ public unsafe class DataDecoder : DecoderBase
                 lock (lockStatus)
                 {
                     CriticalArea = false;
+                    if (Status != Status.QueueEmpty && Status != Status.Draining)
+                        break;
                     if (Status != Status.Draining)
                         Status = Status.Running;
                 }
@@ -136,6 +138,8 @@ public unsafe class DataDecoder : DecoderBase
                 av_packet_free(&packet);
             }
         } while (Status == Status.Running);
+
+        if (Status == Status.Draining) Status = Status.Ended;
     }
 
     private DataFrame ProcessDataFrame(AVPacket* packet)


### PR DESCRIPTION
When connecting to a video stream instead of a file with a data track, disposing the player would trigger a null ref exception because the DataDecoder wouldn't exit when disposed and thus the DataDecoder would read the demuxer field which is null