### PR TITLE
Bad video frames causing crashes

### DIFF
--- a/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
+++ b/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
@@ -504,11 +504,18 @@ public unsafe partial class DecoderContext : PluginHandler
 
         int ret;
         AVPacket* packet;
-        
+
+        const int maxFrameSeekNum = 60;
+        int seekCount = 0;
         lock (VideoDemuxer.lockFmtCtx)
         lock (VideoDecoder.lockCodecCtx)
         while (VideoDemuxer.VideoStream != null && !Interrupt)
         {
+                    
+            if (seekCount > maxFrameSeekNum)
+                return -1;
+            seekCount++;
+
             if (VideoDemuxer.VideoPackets.IsEmpty)
             {
                 packet = av_packet_alloc();
@@ -584,7 +591,7 @@ public unsafe partial class DecoderContext : PluginHandler
                     av_packet_free(&packet);
 
                     if (ret != 0)
-                        return -1;
+                        continue;
                     
                     //VideoDemuxer.UpdateCurTime();
 

--- a/FlyleafLib/MediaPlayer/Player.Extra.cs
+++ b/FlyleafLib/MediaPlayer/Player.Extra.cs
@@ -163,7 +163,23 @@ unsafe partial class Player
                 renderer.ClearOverlayTexture();
 
             if (VideoDecoder.Frames.IsEmpty)
-                vFrame = VideoDecoder.GetFrameNext();
+            {
+                int askedFrame = VideoDecoder.GetFrameNumber(CurTime) + 1;
+                //Log.Debug($"CurTime1: {TicksToTime(CurTime)}, Asked: {askedFrame}");
+                vFrame = VideoDecoder.GetFrame(askedFrame);
+                if (vFrame == null)
+                    return;
+                int recvFrame = VideoDecoder.GetFrameNumber(vFrame.timestamp);
+                //Log.Debug($"CurTime2: {TicksToTime(vFrame.timestamp)}, Got: {recvFrame}");
+                if (askedFrame != recvFrame)
+                {
+                    VideoDecoder.DisposeFrame(vFrame);
+                    vFrame = null;
+                    vFrame = askedFrame < recvFrame
+                        ? VideoDecoder.GetFrame(VideoDecoder.GetFrameNumber(CurTime))
+                        : VideoDecoder.GetFrame(VideoDecoder.GetFrameNumber(CurTime) + 2);
+                }
+            }
             else
                 VideoDecoder.Frames.TryDequeue(out vFrame);
 


### PR DESCRIPTION
In specific cases where video contains bad frames framing forward and jumping can cause the player to crash.