### PR TITLE
Don't change the speed of the video decoder if the stream is not loaded

### DIFF
--- a/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
@@ -68,6 +68,7 @@ public unsafe class VideoDecoder : DecoderBase
 
     protected override void OnSpeedChanged(double value)
     {
+        if (VideoStream == null) return;
         speed = value;
         skipSpeedFrames = speed * VideoStream.FPS / Config.Video.MaxOutputFps;
     }


### PR DESCRIPTION
When speed is changed prior to loading the video stream it will crash
Bug introduced when adding MaxOutputFps