### PR TITLE
fix bug:when returning from fullscreen to normalscreen,missing surface.border.background 

### DIFF
--- a/FlyleafLib/Controls/WPF/FlyleafHost.cs
+++ b/FlyleafLib/Controls/WPF/FlyleafHost.cs
@@ -2172,8 +2172,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
         }
         else
         {
-            Surface.WindowState = WindowState.Normal;
-
+            
             if (IsAttached)
             {
                 Attach(true);
@@ -2193,6 +2192,9 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
 
             if (CornerRadius != zeroCornerRadius)
                 ((Border)Surface.Content).CornerRadius = CornerRadius;
+
+            Surface.WindowState = WindowState.Normal;
+
         }
     }
     public void SetRect(ref Rect rect)


### PR DESCRIPTION
fix bug:when returning from fullscreen to normalscreen, the CornerRadius background has issue it's like a mask color (when play alpha video)