### PR TITLE
Added support for pluggable logger implementation

### DIFF
--- a/FlyleafLib/Engine/Engine.FFmpeg.cs
+++ b/FlyleafLib/Engine/Engine.FFmpeg.cs
@@ -67,7 +67,7 @@ public class FFmpegEngine
         av_log_format_line2(p0, level, format, vl, buffer, AV_LOG_BUFFER_SIZE, &printPrefix);
         string  line = Utils.BytePtrToStringUTF8(buffer);
 
-        Logger.Output($"{DateTime.Now.ToString(Engine.Config.LogDateTimeFormat)} | FFmpeg | {(FFmpegLogLevel)level,-7} | {line.Trim()}");
+        Logger.Output($"FFmpeg|{(FFmpegLogLevel)level,-7}|{line.Trim()}");
     };
 
     internal unsafe static string ErrorCodeToMsg(int error)


### PR DESCRIPTION
This PR modifies the logger class to add support for pluggable logging engines to replace the inbuilt flyleaf logger if desired. This opens the door for circular log sets, better autoflush behavior and other log maintenance features, using the standard MS logging interface, as implemented by packages such as nlog.

The change has been made in a non-breaking way, in that if an app does not set the new static class variable to an iLogger instance, the existing functionality rules.

In this PR I chose not to change the current enum values for the various log levels, but they don't match the iLogger enums, and so I perform an internal conversion as required.

There is one thing that probably needs to be tweaked here: the logging code for ffmpeg level logging - I removed the timestamp on the output statement since this is done higher up in the logger. So it will work correctly when an external logger is plugged in but not for flyleaf native logging.

Finally, when using a pluggable logger such as nLog, you set the logger filter level outside of Flyleaf.  The log levels being used on flyleaf and on ffmpeg still influence what gets logged, but whatever log level is selected there, if the app level log filter is lower than this that is what governs what actually gets logged. So get TRACE on logging. TRACE has to be set on flyleaf level, as well as the app-level log filter level.