### PR TITLE
Player: Adds support for opening windows link files

### DIFF
--- a/FlyleafLib/MediaPlayer/Player.Open.cs
+++ b/FlyleafLib/MediaPlayer/Player.Open.cs
@@ -867,6 +867,16 @@ unsafe partial class Player
     {
         lock (lockActions)
         {
+            if (url_iostream is string url_iostream_str)
+            {
+                // convert Windows lnk file to targetPath
+                if (Path.GetExtension(url_iostream_str).Equals(".lnk", StringComparison.OrdinalIgnoreCase))
+                {
+                    string targetPath = GetLnkTargetPath(url_iostream_str);
+                    url_iostream = targetPath;
+                }
+            }
+            
             if ((url_iostream is string) && ExtensionsSubtitles.Contains(GetUrlExtention(url_iostream.ToString())))
             {
                 OnOpening(new() { Url = url_iostream.ToString(), IsSubtitles = true});

--- a/FlyleafLib/Utils/Utils.cs
+++ b/FlyleafLib/Utils/Utils.cs
@@ -432,6 +432,34 @@ public static partial class Utils
 
         return url;
     }
+    
+    /// <summary>
+    /// Convert Windows lnk file path to target path
+    /// </summary>
+    /// <param name="filepath">lnk file path</param>
+    /// <returns>target path</returns>
+    public static string GetLnkTargetPath(string filepath)
+    {
+        // ref: https://stackoverflow.com/a/64126237
+        using var br = new BinaryReader(System.IO.File.OpenRead(filepath));
+
+        br.ReadBytes(0x14);
+        uint lflags = br.ReadUInt32();
+        if ((lflags & 0x01) == 1)
+        {
+            br.ReadBytes(0x34);
+            var skip = br.ReadUInt16();
+            br.ReadBytes(skip);
+        }
+        var length = br.ReadUInt32();
+        br.ReadBytes(0x0C);
+        var lbpos = br.ReadUInt32();
+        br.ReadBytes((int)lbpos - 0x14);
+        var size = length - lbpos - 0x02;
+        var bytePath = br.ReadBytes((int)size);
+        var path = Encoding.UTF8.GetString(bytePath, 0, bytePath.Length);
+        return path;
+    }
 
     public static string GetBytesReadable(long i)
     {


### PR DESCRIPTION
Added support for direct opening of windows link files.
I thought it needed to be supported on the library side because it also needs to work with drag-and-drop.

Since the following method of using COM did not work without a single-threaded app,
https://stackoverflow.com/questions/43980088/is-there-a-way-in-c-sharp-to-find-the-current-location-of-a-shortcut-target-prog

I chose the following implementation.
https://stackoverflow.com/questions/64126236/reading-the-target-of-a-lnk-file-in-c-sharp-net-core


I have confirmed that it can be opened from drag-and-drop and right-click in WPF's FlyleafPlayer.