### PR TITLE
Disable LowLatency flag from being set automatically

### DIFF
--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -205,8 +205,6 @@ public class Config : NotifyPropertyChanged
                 {
                     if (config.Demuxer.BufferDuration < value * 2)
                         config.Demuxer.BufferDuration = value * 2;
-
-                    config.Decoder.LowDelay = true;
                 }
 
                 // Small min buffer to avoid enabling latency speed directly


### PR DESCRIPTION
Remove enablement of LowDelay config as a default when MaxLatency is set, as the consequences vary according to type of source. (For example, UDP frames from TV can get presented out of order)