### PR TITLE
Plugins.YoutubeDL: Improved video stream selection for YT

### DIFF
--- a/Plugins/YoutubeDL/YoutubeDL.cs
+++ b/Plugins/YoutubeDL/YoutubeDL.cs
@@ -98,10 +98,12 @@ namespace FlyleafLib.Plugins
             var iresults =
                 from    format in ytdl.formats
                 where   HasVideo(format) && format.height <= Config.Video.MaxVerticalResolution && (!Regex.IsMatch(format.protocol, "dash", RegexOptions.IgnoreCase) || format.vcodec.ToLower() == "vp9")
-                orderby format.tbr      descending
-                orderby format.fps      descending
-                orderby format.height   descending
-                orderby format.width    descending
+                orderby format.width    descending,
+                        format.height   descending,
+                        format.protocol descending, // prefer m3u8 over https
+                        format.vcodec,              // prefer avc over vp09 (because YT can't seek vp09 at all)
+                        format.tbr      descending,
+                        format.fps      descending
                 select  format;
             
             if (iresults == null || iresults.Count() == 0)
@@ -110,10 +112,12 @@ namespace FlyleafLib.Plugins
                 iresults =
                     from    format in ytdl.formats
                     where   HasVideo(format)
-                    orderby format.tbr      descending
-                    orderby format.fps      descending
-                    orderby format.height   descending
-                    orderby format.width    descending
+                    orderby format.width    descending,
+                            format.height   descending,
+                            format.protocol descending,
+                            format.vcodec,
+                            format.tbr      descending,
+                            format.fps      descending
                     select  format;
 
                 if (iresults == null || iresults.Count() == 0) return null;


### PR DESCRIPTION
## Description

Fixed video stream selection logic for Youtube playback.

Currently after width and height, the video streams are sorted in descending order by fps,
but some youtube videos may prefer vcodec as vp09 and protocol as m3u8.

I have confirmed that when this combination is used, seek is not possible at all.

error log
```
FFmpeg|Error  |[mov,mp4,m4a,3gp,3g2,mj2 @ 00000202ae334580] root atom offset 0xffffffffffffffff: partial file
23.05.28.832 | Warn  | [#1]     [Demuxer:  Main] Invalid data found when processing input (-1094995529)
23.05.28.833 | Error | [#1]     [Demuxer:  Main] Too many errors!
23.05.28.908 | Debug | [#1]     [Player        ] OnBufferingCompleted (Error: Buffering failed)
23.05.28.909 | Debug | [#1]     [Player        ] [SCREAMER] Finished (Status: Paused, Error: Playback stopped unexpectedly)
```

I confirmed `av_read_frame` in Demuxer.cs returns -1094995529  error code.

I found it difficult to solve the seek problem with vp9 because I could not seek even with mpv when the relevant stream was specified.

```
mpv.exe --cache=no https://manifest.googlevideo.com/xxxxxxxxx/playlist/index.m3u8
```

other players
vlc: OK
mpv: NG (When seeking, no video is displayed, only audio is played.)
PotPlayer: NG (same as mpv)

sample video (my monitor is full hd, vp09 and m3u8 is selected)
https://www.youtube.com/watch?v=dQw4w9WgXcQ

## what changed

### Prefer 'avc' vcodec over 'vp09' because 'vp09' can't be seeked at all

Since avc can be used to seek without problems, I changed the alphabetical sorting to give priority to avc.

### Prefer 'm3u8' protocol over 'https'

because it seems that m3u8 is faster for seek, etc.

### change linq orderby syntax

When multiple orderby's are listed, the bottom one takes precedence, but I thought it would be easier to understand if they were separated by commas.


