### PR TITLE
Player: Fixes an issue with resolving windows link files in external fs

### DIFF
--- a/FlyleafLib/MediaPlayer/Player.Open.cs
+++ b/FlyleafLib/MediaPlayer/Player.Open.cs
@@ -872,8 +872,9 @@ unsafe partial class Player
                 // convert Windows lnk file to targetPath
                 if (Path.GetExtension(url_iostream_str).Equals(".lnk", StringComparison.OrdinalIgnoreCase))
                 {
-                    string targetPath = GetLnkTargetPath(url_iostream_str);
-                    url_iostream = targetPath;
+                    var targetPath = GetLnkTargetPath(url_iostream_str);
+                    if (targetPath != null)
+                        url_iostream = targetPath;
                 }
             }
             


### PR DESCRIPTION
## Description

This PR #505 supported lnk file resolution on Windows,
but as a result of using own implementation, we were not able to support shortcuts to external file systems.

## What changed

I chose to use COM implementation by using dynamic with the following reference.

https://stackoverflow.com/questions/8660705/how-to-follow-a-lnk-file-programmatically/49198242#49198242

## Confirmation

Check with the following files. 

* link file towards C drive
* link file towards NAS
* invalid link file
  * It outputs an error log and results in an avformat_open_input error.
