### PR TITLE
Config: Update viewport when Config.Video.CustomAspectRatio changes

### DIFF
--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -575,7 +575,7 @@ public class Config : NotifyPropertyChanged
         /// <summary>
         /// Custom aspect ratio (AspectRatio must be set to Custom to have an effect)
         /// </summary>
-        public AspectRatio      CustomAspectRatio           { get => _CustomAspectRatio;  set { if (Set(ref _CustomAspectRatio, value)) AspectRatio = AspectRatio.Custom; } }
+        public AspectRatio      CustomAspectRatio           { get => _CustomAspectRatio;  set { if (Set(ref _CustomAspectRatio, value) && AspectRatio == AspectRatio.Custom) { _AspectRatio = AspectRatio.Fill; AspectRatio = AspectRatio.Custom; } } }
         AspectRatio    _CustomAspectRatio = new(16, 9);
 
         /// <summary>


### PR DESCRIPTION
## Description
Fixed a problem where viewport was not updated when custom aspect ratio values were updated.

## How to reproduce

### Bug1: Custom aspect ratio is not reflected to viewport

1. Open FlyleafPlayer WPF and open video
2. Open settings and change "Aspect Ratio" to custom
3. Set "Custom Ratio" to "1:1" but viewport is not updated

### Bug2: Aspect Ratio is fixed to "Custom" when Custom Ratio is set

1. Do Bug1 step and press "Save"
2. Reopen settings and change "Aspect Ratio" to "Keep"
3. Restart and open settings
4. bug: "Aspect Ratio" is set to "Custom" instead of "Keep"

## Whan changes

Stop setting AspectRatio to "Custom" when updating CustomAspectRatio and update viewport only when Custom is used.

The other code is written with a single line of setter, so I aligned it with that.

