### PR TITLE
Player: Fixes an issue that Chapters changes are not updated

### DIFF
--- a/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
+++ b/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
@@ -113,7 +113,8 @@ public unsafe class Demuxer : RunThreadBase
     // Interrupt
     public Interrupter              Interrupter     { get; private set; }
 
-    public List<Chapter>            Chapters        { get; private set; } = new List<Chapter>();
+    public ObservableCollection<Chapter>
+                                    Chapters        { get; private set; } = new ObservableCollection<Chapter>();
     public class Chapter
     {
         public long     StartTime   { get; set; }
@@ -193,6 +194,8 @@ public unsafe class Demuxer : RunThreadBase
             BindingOperations.EnableCollectionSynchronization(VideoStreams,     lockStreams);
             BindingOperations.EnableCollectionSynchronization(SubtitlesStreams, lockStreams);
             BindingOperations.EnableCollectionSynchronization(DataStreams,      lockStreams);
+            
+            BindingOperations.EnableCollectionSynchronization(Chapters,         lockStreams);
         });
 
         ioopen = IOOpen;
@@ -274,6 +277,8 @@ public unsafe class Demuxer : RunThreadBase
                 SubtitlesStreams.Clear();
                 DataStreams.Clear();
                 Programs.Clear();
+                
+                Chapters.Clear();
             }
             EnabledStreams.Clear();
             AudioStream         = null;

--- a/FlyleafLib/MediaPlayer/Player.cs
+++ b/FlyleafLib/MediaPlayer/Player.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading;
 
 using FlyleafLib.Controls;
@@ -152,7 +153,7 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
     /// <summary>
     /// The list of chapters
     /// </summary>
-    public List<Demuxer.Chapter> 
+    public ObservableCollection<Demuxer.Chapter> 
                         Chapters            => VideoDemuxer?.Chapters;
 
     /// <summary>

--- a/FlyleafLib/MediaPlayer/Player.cs
+++ b/FlyleafLib/MediaPlayer/Player.cs
@@ -463,6 +463,7 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
         AudioDecoder.CodecChanged   = Decoder_AudioCodecChanged;
         VideoDecoder.CodecChanged   = Decoder_VideoCodecChanged;
         decoder.RecordingCompleted += (o, e) => { IsRecording = false; };
+        Chapters.CollectionChanged += (o, e) => { RaiseUI(nameof(Chapters)); };
 
         status = Status.Stopped;
         Reset();


### PR DESCRIPTION
## Description
I noticed that the chapter information in the context menu is not updated when another video is opened in the WPF sample player, so I changed it to from List to ObservableCollection.

Also added a change notice to make Player.Chapters bindable. For example, this change notice is needed when adding Ticks to Slider to player.

Example Ticks

```csharp
 <Slider    
     Grid.Column="1" 
     Ticks="{Binding Player.Chapters, Converter={StaticResource ChaptersToTicksConverter}}" />


[ValueConversion(typeof(IEnumerable<Chapter>), typeof(DoubleCollection))]
public class ChaptersToTicksConverter : IValueConverter
{
    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
    {
        if (value is IEnumerable<Chapter> chapters)
        {
            List<double> secs = chapters.Select(c => c.StartTime / 10000000.0).ToList();
            if (secs.Count <= 1)
            {
                return Binding.DoNothing;
            }

            return new DoubleCollection(secs);
        }

        return Binding.DoNothing;
    }

    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
    {
        throw new NotImplementedException();
    }
}
```

## How to reproduce
1. Open WPF FlyleafPlayer 
2. Open video that has chapters
3. Right click to open context menu and there are chapters
4. Open another video that has chapters
5. Open context menu and previous chapters are still (bug)


