### PR TITLE
Player.Keys: ResetAll should be KeyUp

### DIFF
--- a/FlyleafLib/MediaPlayer/Player.Keys.cs
+++ b/FlyleafLib/MediaPlayer/Player.Keys.cs
@@ -520,7 +520,8 @@ public class KeysConfig
         { KeyBindingAction.SpeedRemove2 },
         { KeyBindingAction.ForceIdle },
         { KeyBindingAction.ForceActive },
-        { KeyBindingAction.ForceFullActive }
+        { KeyBindingAction.ForceFullActive },
+        { KeyBindingAction.ResetAll }
     };
 }
 public class KeyBinding


### PR DESCRIPTION
ResetAll was a KeyDown event and has been corrected to a KeyUp event.

I think KeyUp is appropriate since it is not executed continuously.