### PR TITLE
Subtitles: Adds support for .sup bitmap

### DIFF
--- a/FlyleafLib/Plugins/OpenSubtitles.cs
+++ b/FlyleafLib/Plugins/OpenSubtitles.cs
@@ -27,7 +27,7 @@ public class OpenSubtitles : PluginBase, IOpenSubtitles, ISearchLocalSubtitles
         {
             FileInfo fi = new(url);
             title = fi.Extension == null ? fi.Name : fi.Name[..^fi.Extension.Length];
-            converted = fi.Extension.Equals(".sub", StringComparison.OrdinalIgnoreCase);
+            converted = Utils.ExtensionsSubtitlesBitmap.Contains(fi.Extension.TrimStart('.').ToLower());
         }
         catch { title = url; }
 
@@ -92,7 +92,7 @@ public class OpenSubtitles : PluginBase, IOpenSubtitles, ISearchLocalSubtitles
                 bool converted = false;
                 var lang = Language.Unknown;
 
-                if (fi.Extension.Equals(".sub", StringComparison.OrdinalIgnoreCase))
+                if (Utils.ExtensionsSubtitlesBitmap.Contains(fi.Extension.TrimStart('.').ToLower()))
                 {
                     title = fi.Extension == null ? fi.Name : fi.Name[..^fi.Extension.Length];
                     converted = true;

--- a/FlyleafLib/Utils/Utils.cs
+++ b/FlyleafLib/Utils/Utils.cs
@@ -42,10 +42,17 @@ public static partial class Utils
         "apng", "bmp", "gif", "jpg", "jpeg", "png", "ico", "tif", "tiff", "tga","jfif"
     };
 
-    public static List<string> ExtensionsSubtitles = new()
+    public static List<string> ExtensionsSubtitlesText = new()
     {
-        "ass", "ssa", "srt", "sub", "txt", "text", "vtt"
+        "ass", "ssa", "srt", "txt", "text", "vtt"
     };
+
+    public static List<string> ExtensionsSubtitlesBitmap = new()
+    {
+        "sub", "sup"
+    };
+
+    public static List<string> ExtensionsSubtitles = [..ExtensionsSubtitlesText, ..ExtensionsSubtitlesBitmap];
 
     public static List<string> ExtensionsVideo = new()
     {


### PR DESCRIPTION
Added support for bitmap subtitles in .sup.

OpenSubtitles is not modified because it supports only srt for text subtitles.

https://github.com/SuRGeoNix/Flyleaf/blob/35ab3473d97025aaeb49cf5ffeb31a7ddd69003d/FlyleafLib/Plugins/OpenSubtitles.cs#L64

I confirmed that it works with sup and sub subtitles.

