### PR TITLE
Playlist: Fix not updating next/prev item when added/reset

### DIFF
--- a/FlyleafLib/MediaFramework/MediaPlaylist/Playlist.cs
+++ b/FlyleafLib/MediaFramework/MediaPlaylist/Playlist.cs
@@ -131,6 +131,8 @@ public class Playlist : NotifyPropertyChanged
             Items.Add(item);
             Items[^1].Index = Items.Count - 1;
 
+            UpdatePrevNextItem();
+
             if (tag != null)
                 item.AddTag(tag, pluginName);
         };

--- a/FlyleafLib/MediaFramework/MediaPlaylist/Playlist.cs
+++ b/FlyleafLib/MediaFramework/MediaPlaylist/Playlist.cs
@@ -102,6 +102,8 @@ public class Playlist : NotifyPropertyChanged
         _Url        = null;
         _Title      = null;
         _Selected   = null;
+        PrevItem    = null;
+        NextItem    = null;
         IOStream    = null;
         FolderBase  = null;
         Completed   = false;


### PR DESCRIPTION
## Overview

Fixed playlist next and previous button updates not working properly.

## How to reproduce

### Bug 1: When an item is added, the next button does not appear

1. Open Youtube any playlist URL in Flyleaf WPF Sample
2. Wait until playlist items are added
3. Next playlist item button in FlyleafBar does not appear (bug)

### Bug 2: When the playlist reset, the next and previous buttons do not disappear

1. Open Youtube any playlist URL in Flyleaf WPF Sample
2. Select next item in playlist from ContextMenu to enable prev/next buttons
4. Press CTRL+Q to reset
5. prev/next buttons in FlyleafBar do not disappear (bug)
