### PR TITLE
Minor performance optimization for NotifyPropertyChanged, Language

### DIFF
--- a/FlyleafLib/Engine/Globals.cs
+++ b/FlyleafLib/Engine/Globals.cs
@@ -120,7 +120,7 @@ public enum VideoFilters
     StereoAdjustment    = 0x80
 }
 
-public struct AspectRatio
+public struct AspectRatio : IEquatable<AspectRatio>
 {
     public static readonly AspectRatio Keep     = new(-1, 1);
     public static readonly AspectRatio Fill     = new(-2, 1);
@@ -160,11 +160,11 @@ public struct AspectRatio
     public AspectRatio(float num, float den) { Num = num; Den = den; }
     public AspectRatio(string value) { Num = Invalid.Num; Den = Invalid.Den; FromString(value); }
 
-    public override bool Equals(object obj) => (obj == null) || !GetType().Equals(obj.GetType()) ? false : Num == ((AspectRatio)obj).Num && Den == ((AspectRatio)obj).Den;
+    public bool Equals(AspectRatio other) => Num == other.Num && Den == other.Den;
+    public override bool Equals(object obj) => obj is AspectRatio o && Equals(o);
+    public override int GetHashCode() => HashCode.Combine(Num, Den);
     public static bool operator ==(AspectRatio a, AspectRatio b) => a.Equals(b);
     public static bool operator !=(AspectRatio a, AspectRatio b) => !(a == b);
-
-    public override int GetHashCode() => (int)(Value * 1000);
 
     public void FromString(string value)
     {
@@ -217,7 +217,7 @@ public class NotifyPropertyChanged : INotifyPropertyChanged
     {
         //Utils.Log($"[===| {propertyName} |===] | Set | {IsUI()}");
 
-        if (!check || (field == null && value != null) || (field != null && !field.Equals(value)))
+        if (!check || !EqualityComparer<T>.Default.Equals(field, value))
         {
             field = value;
 
@@ -234,7 +234,7 @@ public class NotifyPropertyChanged : INotifyPropertyChanged
     {
         //Utils.Log($"[===| {propertyName} |===] | SetUI | {IsUI()}");
 
-        if (!check || (field == null && value != null) || (field != null && !field.Equals(value)))
+        if (!check || !EqualityComparer<T>.Default.Equals(field, value))
         {
             field = value;
 

--- a/FlyleafLib/Engine/Language.cs
+++ b/FlyleafLib/Engine/Language.cs
@@ -92,7 +92,7 @@ public class Language : IEquatable<Language>
 
     public static CultureInfo StringToCulture(string lang)
     {
-        if (string.IsNullOrWhiteSpace(lang) || lang.Length < 2)
+        if (string.IsNullOrWhiteSpace(lang) || lang.Length < 2 || lang == "und")
             return null;
 
         string langLower = lang.ToLower();
@@ -103,10 +103,12 @@ public class Language : IEquatable<Language>
             ret = lang.Length == 3 ? ThreeLetterToCulture(langLower) : CultureInfo.GetCultureInfo(langLower);
         } catch { }
 
+        StringComparer cmp = StringComparer.OrdinalIgnoreCase;
+
         // TBR: Check also -Country/region two letters?
         if (ret == null || ret.ThreeLetterISOLanguageName == "")
             foreach (var cult in CultureInfo.GetCultures(CultureTypes.AllCultures))
-                if (cult.Name.ToLower() == langLower || cult.NativeName.ToLower() == langLower || cult.EnglishName.ToLower() == langLower)
+                if (cmp.Equals(cult.Name, langLower) || cmp.Equals(cult.NativeName, langLower) || cmp.Equals(cult.EnglishName, langLower))
                     return cult;
 
         return ret;


### PR DESCRIPTION
Small performance optimizations were made.

## Avoid boxing for NotifyPropertyChanged

Because the call to `obj.Equals()` causes boxing when int, double, or struct of a value type is used in Set<T>, I changed to use `EqualityComparer<T>.Default` to compare.

```
The Default property checks whether type T implements the System.IEquatable<T> interface and, if so, returns an EqualityComparer<T> that uses that implementation. Otherwise, it returns an EqualityComparer<T> that uses the overrides of Object.Equals and Object.GetHashCode provided by T.
```
https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.equalitycomparer-1.default?view=net-8.0

Types that implement `IEquatable<T>` can be compared without boxing, so I also implemented that in the user type structure `AspectRatio`.

## Case-insensitive match using StringComparer

Case-insensitive string comparison in the Language class has been modified to use StringComparer.
Because comparisons are performed for all Cultures, performance is improved slightly when an invalid string is passed in `Language.Get()`.