### PR TITLE
Interrupter: Reset timeout state on Read

### DIFF
--- a/FlyleafLib/MediaFramework/MediaDemuxer/Interrupter.cs
+++ b/FlyleafLib/MediaFramework/MediaDemuxer/Interrupter.cs
@@ -65,6 +65,7 @@ public unsafe class Interrupter
         if (!demuxer.Config.AllowTimeouts)
             return;
 
+        Timedout    = false;
         curTimeoutMs= demuxer.IsLive ? demuxer.Config.readLiveTimeoutMs: demuxer.Config.readTimeoutMs;
         sw.Restart();
     }


### PR DESCRIPTION
I reset the timed out status in the Read interrupter, as it was probably not intended.

When a read timed out, it is necessary to seek to resume playback, but the status is reset at that time, so there seemed to be no problem with the current implementation. However, I don't think it was intended, so it is fixed.