### PR TITLE
QoL: Reset zoom smaller than 1 and don't let user pan out of more than half of the video frame

### DIFF
--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
@@ -324,6 +324,38 @@ public partial class Renderer
             yZoomPixels = newHeight - (ControlHeight - SideYPixels);
         }
 
+        // Don't let the user pan or zoom outside of half the video's height
+        int newY = (int)(y - yZoomPixels * (float)zoomCenter.Y);
+        int bottom = newHeight + newY;
+        if (newY > ControlHeight / 2d)
+        {
+            y = (int)((ControlHeight / 2d) + yZoomPixels * (float)zoomCenter.Y);
+            panYOffset = y - SideYPixels / 2;
+        }
+        else if (bottom < ControlHeight / 2d)
+        {
+            int newBottom = (int)(ControlHeight / 2d);
+            int newNewY = newBottom - newHeight;
+            y = (int)(newNewY + yZoomPixels * (float)zoomCenter.Y);
+            panYOffset = y - SideYPixels / 2;
+        }
+
+        // Don't let the user pan or zoom outside of half the video's width
+        int newX = (int)(x - xZoomPixels * (float)zoomCenter.X);
+        int right = newWidth + newX;
+        if (newX > ControlWidth / 2d)
+        {
+            x = (int)((ControlWidth / 2d) + xZoomPixels * (float)zoomCenter.X);
+            panXOffset = x - SideXPixels / 2;
+        }
+        else if (right < ControlWidth / 2d)
+        {
+            int newRight = (int)(ControlWidth / 2d);
+            int newNewX = newRight - newWidth;
+            x = (int)(newNewX + xZoomPixels * (float)zoomCenter.X);
+            panXOffset = x - SideXPixels / 2;
+        }
+
         GetViewport = new(x - xZoomPixels * (float)zoomCenter.X, y - yZoomPixels * (float)zoomCenter.Y, newWidth, newHeight);
         ViewportChanged?.Invoke(this, new());
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.cs
@@ -121,6 +121,12 @@ public partial class Renderer : NotifyPropertyChanged, IDisposable
     {
         lock(lockDevice)
         {
+            if (zoom < 1)
+            {
+                ResetPanAndZoom();
+                return;
+            }
+
             this.zoom = zoom;
 
             if (Disposed)
@@ -150,6 +156,12 @@ public partial class Renderer : NotifyPropertyChanged, IDisposable
     {
         lock(lockDevice)
         {
+            if (zoom < 1)
+            {
+                ResetPanAndZoom();
+                return;
+            }
+
             this.zoom = zoom;
             zoomCenter = p;
 
@@ -176,6 +188,14 @@ public partial class Renderer : NotifyPropertyChanged, IDisposable
             if (refresh)
                 SetViewport();
         }
+    }
+
+    private void ResetPanAndZoom()
+    {
+        panXOffset = panYOffset = 0;
+        zoom = 1;
+        zoomCenter = ZoomCenterPoint;
+        SetViewport();
     }
 
     public int              UniqueId        { get; private set; }


### PR DESCRIPTION
Quality of life changes:
If the user zoom's out so the video is smaller than the control, we reset zoom and pan for simplicity of use.
Don't let the user pan outside of more than half the video frame with current zoom. It's easy to "lose" the video frame when panning and having zoom and resizing the window.

I can update and put this behind config if that is preferable.