### PR TITLE
Better data frame sync

### DIFF
--- a/FlyleafLib/MediaPlayer/Player.Screamers.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.cs
@@ -442,7 +442,7 @@ unsafe partial class Player
                 ? (int)((((dFrame.timestamp - startTicks) / speed) - elapsedTicks) / 10000)
                 : int.MaxValue;
 
-            sleepMs = Math.Min(vDistanceMs, aDistanceMs) - 1;
+            sleepMs = Math.Min(dDistanceMs, Math.Min(vDistanceMs, aDistanceMs)) - 1;
             if (sleepMs < 0 || sleepMs == int.MaxValue)
                 sleepMs = 0;
 

--- a/FlyleafLib/MediaPlayer/Player.cs
+++ b/FlyleafLib/MediaPlayer/Player.cs
@@ -552,6 +552,7 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
         Video.Reset();
         Audio.Reset();
         Subtitles.Reset();
+        Data.Reset();
         UIAll();
     }
     private void Initialize(Status status = Status.Stopped, bool andDecoder = true, bool isSwitch = false)


### PR DESCRIPTION
Since we did not use the distance to the next data frame when calculating sleepMs we put ourselves in a situation if the closest frame was a dataframe, we could wait too long to "show" it. This caused data frames to queue up and lag behind.

Also fixed data not being reset on Player.Reset.