### PR TITLE
Added rolling log appender

### DIFF
--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -1021,6 +1021,16 @@ public class EngineConfig
     public int      LogCachedLines          { get; set; } = 20;
 
     /// <summary>
+    /// Max filesize of log before starting a new log file when <see cref="LogMaxNumberOfBackupFiles"/> is greater than 0
+    /// </summary>
+    public long     LogFileSizeMax          { get; set; } = 1024 * 1024;
+
+    /// <summary>
+    /// Max number of backup logfiles to roll over before deleting the oldest, setting this to 0 disables rollover
+    /// </summary>
+    public long     LogMaxNumberOfBackupFiles { get; set; } = 5;
+
+    /// <summary>
     /// Sets the logger's datetime string format
     /// </summary>
     public string   LogDateTimeFormat       { get; set; } = "HH.mm.ss.fff";


### PR DESCRIPTION
Proposal for adding a rolling log appender.
Introduces two new config properties:
LogMaxNumberOfBackupFiles - How many files to roll over before deleting the oldest (0 disables this)
LogFileSizeMax - How big the files can become before rolling over (only applies if LogMaxNumberOfBackupFiles > 0)

This ensures that logs can grow indefinitely and that files never grow too big.

I just put some default I thought was reasonable, but we can change these if they are not