### PR TITLE
Only set lastVideoPacketPts when video packet has pts

### DIFF
--- a/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
+++ b/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
@@ -1116,7 +1116,7 @@ public unsafe class Demuxer : RunThreadBase
         int allowedErrors = Config.MaxErrors;
         bool gotAVERROR_EXIT = false;
         audioBufferLimitFired = false;
-        long lastVideoPacketPts = 0;
+        long lastVideoPacketPts = AV_NOPTS_VALUE;
 
         do
         {
@@ -1245,7 +1245,14 @@ public unsafe class Demuxer : RunThreadBase
                             // Some data streams only have nopts, set pts to last video packet pts
                             if (packet->pts == AV_NOPTS_VALUE)
                                 packet->pts = lastVideoPacketPts;
-                            DataPackets.Enqueue(packet);
+                            if (packet->pts != AV_NOPTS_VALUE)
+                            {
+                                DataPackets.Enqueue(packet);
+                            }
+                            else
+                            {
+                                av_packet_unref(packet);
+                            }
                             packet = av_packet_alloc();
 
                             break;


### PR DESCRIPTION
In rare instances, some video packets do not have PTS.
This change makes sure we only queue data packets that has pts.
Changed lastVideoPts to start out as no pts to prevent rare case of having a data packet with ts 0