### PR TITLE
Added engine config option to disable permanent display powerd on

### DIFF
--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -1078,6 +1078,11 @@ public class EngineConfig
     public int      UIRefreshInterval       { get; set; } = 250;
 
     /// <summary>
+    /// Keep display powered on while video is playing
+    /// </summary>
+    public bool     KeepDisplayActive       { get; set; } = true;
+
+    /// <summary>
     /// Loads engine's configuration
     /// </summary>
     /// <param name="path">Absolute or relative path to load the configuraiton</param>

--- a/FlyleafLib/Engine/Engine.cs
+++ b/FlyleafLib/Engine/Engine.cs
@@ -123,7 +123,7 @@ public static class Engine
                 Log.Trace("ThreadExecutionStateBegin");
                 #endif
 
-                _ = NativeMethods.SetThreadExecutionState(NativeMethods.EXECUTION_STATE.ES_CONTINUOUS | NativeMethods.EXECUTION_STATE.ES_SYSTEM_REQUIRED | NativeMethods.EXECUTION_STATE.ES_DISPLAY_REQUIRED);
+                _ = NativeMethods.SetThreadExecutionState(NativeMethods.EXECUTION_STATE.ES_CONTINUOUS | NativeMethods.EXECUTION_STATE.ES_SYSTEM_REQUIRED | (Config.KeepDisplayActive ? NativeMethods.EXECUTION_STATE.ES_DISPLAY_REQUIRED : 0));
             }
         }
     }


### PR DESCRIPTION
Currently flyleaf always disable the windows display timeout while a video is playing. This adds a config option to disable this behaviour, the default is still the same.