### PR TITLE
Add easier way of getting bitmapsource snapshots

### DIFF
--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Snapshot.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Snapshot.cs
@@ -33,22 +33,10 @@ public unsafe partial class Renderer
         return snapshot = new(device, vd, ve, width, height);
     }
 
-    public Bitmap TakeSnapshot(uint width = 0, uint height = 0)
+    ID3D11Texture2D GetTexture(Snapshot snapshot)
     {
         try
         {
-            if (width == 0 && height == 0)
-            {
-                width  = VisibleWidth;
-                height = VisibleHeight;
-            }
-            else if (width != 0 && height == 0)
-                height = (uint)(width / curRatio);
-            else if (height != 0 && width == 0)
-                width  = (uint)(height * curRatio);
-
-            var snapshot = GetSnapshot(width, height);
-
             lock (lockRenderLoops)
             {
                 var rFrame = Frames.RendererFrame;
@@ -70,12 +58,35 @@ public unsafe partial class Renderer
                     context.RSSetViewport(Viewport);
                 }
             }
-            
+
             context.CopyResource(snapshot.txtStage, snapshot.txt);
 
-            return GetBitmap(snapshot.txtStage);
+            return snapshot.txtStage;
         }
-        catch { return null; }   
+        catch { return null; }
+    }
+
+    public Bitmap TakeSnapshot(uint width = 0, uint height = 0)
+    {
+        try
+        {
+            if (width == 0 && height == 0)
+            {
+                width = VisibleWidth;
+                height = VisibleHeight;
+            }
+            else if (width != 0 && height == 0)
+                height = (uint)(width / curRatio);
+            else if (height != 0 && width == 0)
+                width = (uint)(height * curRatio);
+
+            var snapshot = GetSnapshot(width, height);
+            var texture = GetTexture(snapshot);
+            if (texture is null)
+                return null;
+            return GetBitmap(texture);
+        }
+        catch { return null; }
     }
 
     public BitmapSource TakeSnapshotBitmapSource(uint width = 0, uint height = 0)
@@ -93,32 +104,10 @@ public unsafe partial class Renderer
                 width = (uint)(height * curRatio);
 
             var snapshot = GetSnapshot(width, height);
-
-            lock (lockRenderLoops)
-            {
-                var rFrame = Frames.RendererFrame;
-
-                if (rFrame == null)
-                    return null;
-
-                if (VideoProcessor == VideoProcessors.D3D11)
-                {
-                    vc.VideoProcessorGetStreamDestRect(vp, 0, out _, out var d3destOld);
-                    vc.VideoProcessorGetOutputTargetRect(vp, out _, out var d3outOld);
-                    D3Render(rFrame.VPIV, snapshot.d3rtv, snapshot.d3view);
-                    vc.VideoProcessorSetStreamDestRect(vp, 0, true, d3destOld);
-                    vc.VideoProcessorSetOutputTargetRect(vp, true, d3outOld);
-                }
-                else
-                {
-                    FLRender(rFrame.SRV, snapshot.rtv, snapshot.view);
-                    context.RSSetViewport(Viewport);
-                }
-            }
-
-            context.CopyResource(snapshot.txtStage, snapshot.txt);
-
-            return GetBitmapSource(snapshot.txtStage);
+            var texture = GetTexture(snapshot);
+            if (texture is null)
+                return null;
+            return GetBitmapSource(texture);
         }
         catch { return null; }
     }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Snapshot.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Snapshot.cs
@@ -78,6 +78,51 @@ public unsafe partial class Renderer
         catch { return null; }   
     }
 
+    public BitmapSource TakeSnapshotBitmapSource(uint width = 0, uint height = 0)
+    {
+        try
+        {
+            if (width == 0 && height == 0)
+            {
+                width = VisibleWidth;
+                height = VisibleHeight;
+            }
+            else if (width != 0 && height == 0)
+                height = (uint)(width / curRatio);
+            else if (height != 0 && width == 0)
+                width = (uint)(height * curRatio);
+
+            var snapshot = GetSnapshot(width, height);
+
+            lock (lockRenderLoops)
+            {
+                var rFrame = Frames.RendererFrame;
+
+                if (rFrame == null)
+                    return null;
+
+                if (VideoProcessor == VideoProcessors.D3D11)
+                {
+                    vc.VideoProcessorGetStreamDestRect(vp, 0, out _, out var d3destOld);
+                    vc.VideoProcessorGetOutputTargetRect(vp, out _, out var d3outOld);
+                    D3Render(rFrame.VPIV, snapshot.d3rtv, snapshot.d3view);
+                    vc.VideoProcessorSetStreamDestRect(vp, 0, true, d3destOld);
+                    vc.VideoProcessorSetOutputTargetRect(vp, true, d3outOld);
+                }
+                else
+                {
+                    FLRender(rFrame.SRV, snapshot.rtv, snapshot.view);
+                    context.RSSetViewport(Viewport);
+                }
+            }
+
+            context.CopyResource(snapshot.txtStage, snapshot.txt);
+
+            return GetBitmapSource(snapshot.txtStage);
+        }
+        catch { return null; }
+    }
+
     #region Bitmap Helpers
     public Bitmap GetBitmap(VideoFrame frame, uint width = 0, uint height = 0)
     {   // Extractor example (should be used separate from Player-OnScreen rendering)

--- a/FlyleafLib/MediaPlayer/Player.Extra.cs
+++ b/FlyleafLib/MediaPlayer/Player.Extra.cs
@@ -340,6 +340,16 @@ unsafe partial class Player
     /// <returns></returns>
     public System.Drawing.Bitmap TakeSnapshotToBitmap(uint width = 0, uint height = 0) => Renderer?.TakeSnapshot(width, height);
 
+    /// <summary>
+    /// <para>Returns a bitmap of the current or specified video frame</para>
+    /// <para>If width/height not specified will use the original size. If one of them will be set, the other one will be set based on original ratio</para>
+    /// <para>If frame not specified will use the current/last frame</para>
+    /// </summary>
+    /// <param name="width">Specify the width (0: will keep the ratio based on height)</param>
+    /// <param name="height">Specify the height (0: will keep the ratio based on width)</param>
+    /// <returns></returns>
+    public System.Windows.Media.Imaging.BitmapSource TakeSnapshotToBitmapSource(uint width = 0, uint height = 0) => Renderer?.TakeSnapshotBitmapSource(width, height);
+
     public void ResetAll()
     {
         ReversePlayback = false;


### PR DESCRIPTION
After the renderer refactoring, users need to call renderer and provide a texture in order to get a bitmapsource snapshot.
This PR adds a TakeSnapshotToBitmapSource that mirrors TakeSnapshotToBitmap