### PR TITLE
Fix headless RenderPlay not tracking frames for TakeSnapshot

### DIFF
--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
@@ -168,6 +168,7 @@ public unsafe partial class Renderer
                 {
                     if (vpRequestsIn != VPRequestType.Empty)
                     {
+                        vpRequestsIn &= ~VPRequestType.Resize;
                         if (VideoProcessor == VideoProcessors.D3D11)
                             D3ProcessRequests();
                         else

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
@@ -165,7 +165,16 @@ public unsafe partial class Renderer
                 // Matches v3.9.7 behavior where LastFrame was always set
                 // Must hold lockRenderLoops to synchronize with TakeSnapshot
                 lock (lockRenderLoops)
+                {
+                    if (vpRequestsIn != VPRequestType.Empty)
+                    {
+                        if (VideoProcessor == VideoProcessors.D3D11)
+                            D3ProcessRequests();
+                        else
+                            FLProcessRequests();
+                    }
                     Frames.SetRendererFrame(frame);
+                }
                 return true;
             }
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
@@ -160,7 +160,14 @@ public unsafe partial class Renderer
             lastRenderAt = DateTime.UtcNow.Ticks;
 
             if (!SwapChain.CanPresent)
+            {
+                // Still track the frame for headless use (TakeSnapshot)
+                // Matches v3.9.7 behavior where LastFrame was always set
+                // Must hold lockRenderLoops to synchronize with TakeSnapshot
+                lock (lockRenderLoops)
+                    Frames.SetRendererFrame(frame);
                 return true;
+            }
 
             lock (lockRenderLoops)
             {

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.cs
@@ -240,7 +240,17 @@ public unsafe partial class Renderer : IVP
 
         if (player != null)
         {
-            if (request)
+            if (!SwapChain.CanPresent)
+            {
+                // Headless: process VP requests immediately since render loop won't run
+                vpRequestsIn |= vpRequests;
+                vpRequestsIn &= ~VPRequestType.Resize;
+                if (VideoProcessor == VideoProcessors.D3D11)
+                    D3ProcessRequests();
+                else
+                    FLProcessRequests();
+            }
+            else if (request)
                 VPRequest(vpRequests);
             else
                 vpRequestsIn |= vpRequests;

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.cs
@@ -243,12 +243,15 @@ public unsafe partial class Renderer : IVP
             if (!SwapChain.CanPresent)
             {
                 // Headless: process VP requests immediately since render loop won't run
-                vpRequestsIn |= vpRequests;
-                vpRequestsIn &= ~VPRequestType.Resize;
-                if (VideoProcessor == VideoProcessors.D3D11)
-                    D3ProcessRequests();
-                else
-                    FLProcessRequests();
+                lock (lockRenderLoops)
+                {
+                    vpRequestsIn |= vpRequests;
+                    vpRequestsIn &= ~VPRequestType.Resize;
+                    if (VideoProcessor == VideoProcessors.D3D11)
+                        D3ProcessRequests();
+                    else
+                        FLProcessRequests();
+                }
             }
             else if (request)
                 VPRequest(vpRequests);


### PR DESCRIPTION
In v3.10.2, RenderPlay returns early without calling Frames.SetRendererFrame when SwapChain.CanPresent is false. This breaks TakeSnapshot for headless/offscreen consumers that extract frames without a visible window.

In v3.9.7, RenderPlay always set LastFrame regardless of canRenderPresent. Restore that behavior so TakeSnapshot can access the current frame even without a SwapChain.