### PR TITLE
Config: Fixes default back color transparency

### DIFF
--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.cs
@@ -434,7 +434,7 @@ public class VPConfig : NotifyPropertyChanged
     /// </summary>
     public System.Windows.Media.Color
                             BackColor               { get => VorticeToWPFColor(flBackColor);  set { if (Set(ref flBackColor, WPFToVorticeColor(value))) { d3BackColor = WPFToVideoColor(value); vp?.VPRequest(VPRequestType.BackColor); } } }
-    internal Color flBackColor = new(0, 0, 0, 1);
+    internal Color flBackColor = new(0, 0, 0, 255);
     internal VideoColor d3BackColor = new() { Rgba = new() { R = 0, G = 0, B = 0, A = 1 } };
 
     // === Viewport ===


### PR DESCRIPTION
This fixes the issue where the default background color is set to transparent black.
Since Vortice's `Color` is an integer rather than a float, the correct value for non-transparent is 255, not 1.
https://github.com/amerkoleci/Vortice.Mathematics/blob/fa05ec6dcba48f3f7331791da6dc7f3d866b2ad6/src/Vortice.Mathematics/Color.cs#L118-L145

In the sample WPF FlyleafPlayer, the issue does not occur because the value is overwritten with a non-transparent color at the following location in `FlyleafME`
https://github.com/SuRGeoNix/Flyleaf/blob/9fe23d5b5204ddd7496ecbb3224a51bdabd9d0bb/FlyleafLib.Controls.WPF/FlyleafME.cs#L158-L159

but in projects that do not use `FlyleafME`, such as `FlyleafPlayer (Custom - Rounded Corners) (WPF)`, the background color becomes transparent.

