### PR TITLE
Update Engine.Audio.cs - Fix audio halt and deadlock on audio device switch

### DIFF
--- a/FlyleafLib/Engine/Engine.Audio.cs
+++ b/FlyleafLib/Engine/Engine.Audio.cs
@@ -123,6 +123,8 @@ public class AudioEngine : CallbackBase, IMMNotificationClient, INotifyPropertyC
             {
                 List<AudioEndpoint> curs     = [];
                 List<AudioEndpoint> removed  = [];
+               //Declare TargetDeviceId so we can access while device changes and set it accordingly
+                string targetDeviceId = null;
 
                 lock (lockDevices)
                 {
@@ -164,25 +166,38 @@ public class AudioEngine : CallbackBase, IMMNotificationClient, INotifyPropertyC
                         Devices.Remove(device);
                 }
 
-                var defaultDevice =  deviceEnum.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
-                if (defaultDevice != null && CurrentDevice.Id != defaultDevice.Id)
-                {
-                    CurrentDevice.Id    = defaultDevice.Id;
-                    CurrentDevice.Name  = defaultDevice.FriendlyName;
-                    PropertyChanged?.Invoke(this, new(nameof(CurrentDevice)));
-                }
+                  var defaultDevice = deviceEnum.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+
+  if (defaultDevice != null)
+  {
+      targetDeviceId = defaultDevice.Id;
+  }
+    // OceanCyan: Switched to a proactive default device sync in Task.Run below.
+//Only switch if Id has actually changed. This makes sure even if device is connected and removed repetitively, infinite loops do not occur.
+    if (targetDeviceId != null && targetDeviceId != CurrentDevice.Id)
+  {
+      Task.Run(() =>
+      {
+      //give time to refresh and then set
+          Thread.Sleep(300);
+          SetDevice(targetDeviceId);
+      });
+  }
 
                 // Fall back to DefaultDevice *Non-UI thread otherwise will freeze (not sure where and why) during xaudio.Dispose()
-                if (removed.Count > 0)
-                    Task.Run(() =>
-                    {
-                        foreach(var device in removed)
-                        {
-                            foreach(var player in Engine.Players)
-                                if (player.Audio.Device == device)
-                                    player.Audio.Device = DefaultDevice;
-                        }
-                    });
+              
+// This old logic only triggered on 'removed', whereas the new logic now handles both additons and removals of audio devices to the hardware by syncing to the current Windows default.
+
+                   //if (removed.Count > 0)
+    //    Task.Run(() =>
+    //    {
+    //        foreach(var device in removed)
+    //        {
+    //            foreach(var player in Engine.Players)
+    //                if (player.Audio.Device == device)
+    //                    player.Audio.Device = DefaultDevice;
+    //        }
+    //    });
             }
         });
     }


### PR DESCRIPTION
This pull request is for a critical issue/bug where switching audio devices (e.g., connecting or disconnecting earphones or headphones into the audio port) causes the audio playback to stall, the seek bar to break. This behavior was observed in both WinUI 3 and WPF framework.

Root Cause:
Deadlock: Attempting to update player.Audio.Device on the UI thread leads to a deadlock during the xaudio.Dispose() process.

Logic Gap: The previous RefreshDevices method only forced a device update when a device was removed. Which caused no switch in the audio device and player refused to play with no error code or output.

Changes:
Offloaded Device Switching: Moved the assignment of player.Audio.Device to a background Task.Run to decouple it from the UI thread and prevent xaudio.Dispose() deadlocks.

Proactive Default Sync: Added a check to detect and identify when the system's default multimedia Endpoint changes. The engine now switches to the current/new Default regardless of whether an audio device was added or removed.

Slight Delay: Added a 200ms Thread.Sleep before re-initialization to allow OS/Realtek drivers to stabilize and refresh after a device connect/disconnect.

Some Code Cleanup: Now that i have consolidated the logic into a single source of code based on the current Default device Id, I have commented the code that could have potentially caused clash with the new code and then infinite loops. If you feel that code is no longer necessary, you can remove it. I have tested the new code in the sample player before testing in my own app, by repetitively connecting and disconnecting my headphones and it worked fine with just a tiny break. Other than that, everything else would work fine, I hope.

Please do review the changes i made and consider possibly integrating them into the official release.