### PR TITLE
Renderer: dispose live frames before re-alloc on source switch

### DIFF
--- a/FlyleafLib/MediaFramework/MediaFrame/VideoFrame.cs
+++ b/FlyleafLib/MediaFramework/MediaFrame/VideoFrame.cs
@@ -14,8 +14,15 @@ public unsafe class VideoFrame : FrameBase
     public VideoFrame Prev, Next;
     public long Id;
 
+    // Renderer that created this frame; used to deterministically untrack/dispose frames that
+    // escaped the VideoCache when the renderer switches source or is torn down (see Renderer.DisposeLiveFrames).
+    internal MediaRenderer.Renderer Owner;
+
     public void Dispose()
     {   // Manually dipose only when not in VC
+        Owner?.UntrackFrame(this);
+        Owner = null;
+
         Prev = Next = null; // Could null Next.Prev here
 
         DisposeTexture();

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
@@ -49,6 +49,56 @@ public unsafe partial class Renderer : NotifyPropertyChanged
     ID3D11DeviceContext     context;
     bool                    forceWarp;
 
+    // All VideoFrames this renderer created and not yet disposed. A frame can escape the VideoCache
+    // (source switch / seek / screamer hand-off) and then be abandoned without Dispose(); its native
+    // surface/SRV/VPIV (and pinned AVFrame) would only be freed by non-deterministic COM finalizers,
+    // keeping the D3D11 device referenced so the driver never reclaims the surface memory. Tracking
+    // them lets us dispose any survivors deterministically on source switch and on teardown.
+    readonly HashSet<MediaFrame.VideoFrame> liveFrames = [];
+    readonly object         lockLiveFrames = new();
+
+    internal void TrackFrame(MediaFrame.VideoFrame frame)
+    {
+        frame.Owner = this;
+        lock (lockLiveFrames)
+            liveFrames.Add(frame);
+    }
+
+    internal void UntrackFrame(MediaFrame.VideoFrame frame)
+    {
+        lock (lockLiveFrames)
+            liveFrames.Remove(frame);
+    }
+
+    internal void DisposeLiveFrames()
+    {
+        MediaFrame.VideoFrame[] survivors;
+        lock (lockLiveFrames)
+        {
+            if (liveFrames.Count == 0)
+                return;
+
+            survivors = [.. liveFrames];
+            liveFrames.Clear();
+        }
+
+        foreach (var frame in survivors)
+        {
+            frame.Owner = null; // already removed from set; avoid re-entrant Untrack
+            frame.Dispose();
+        }
+    }
+
+    // Forces D3D11 to process deferred destruction of just-released resources. D3D11 defers destroying
+    // a released resource until the next Flush / GPU idle; for a paused or source-switched player there
+    // is no Present to trigger it, so the freed surface memory lingers until then.
+    internal void FlushContext()
+    {
+        lock (lockDevice)
+            if (!Disposed && context != null)
+                context.Flush();
+    }
+
     internal LogHandler     Log;
     Player                  player;
     ID2D1Device             device2d;
@@ -248,6 +298,7 @@ public unsafe partial class Renderer : NotifyPropertyChanged
             if (!isDeviceReset)
                 RenderIdleStop(); // Ensures it didn't start again (after CanPresent = false)
             Frames.Dispose();
+            DisposeLiveFrames(); // dispose any frames that escaped the cache so no native view/AVFrame keeps the device referenced
             D3Dispose();
             FLDispose();
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.D3.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.D3.cs
@@ -161,7 +161,7 @@ public unsafe partial class Renderer
     }
     bool D3HWConfig()
     {
-        FillPlanes  = D3HWFillPlanes;
+        fillPlanes  = D3HWFillPlanes;
         psCase      = PSCase.HWD3;
 
         d3txtDesc.Width = scfg.txtWidth;
@@ -182,8 +182,8 @@ public unsafe partial class Renderer
         context.VSSetShader(vsSimple);
         vpivd.Texture2D.ArraySlice = 0;
 
-        D3FillPlanesStage   = FillPlanes;
-        FillPlanes          = D3SWFillPlanes;
+        D3FillPlanesStage   = fillPlanes;
+        fillPlanes          = D3SWFillPlanes;
         psCase              = PSCase.SWD3;
         d3txtDesc.Width     = scfg.txtWidth  & ~1u;
         d3txtDesc.Height    = scfg.txtHeight & ~1u;

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.FL.PS.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.FL.PS.cs
@@ -99,7 +99,7 @@ color = float4(
     }
     bool FLHWConfig()
     {
-        FillPlanes = FLHWFillPlanes;
+        fillPlanes = FLHWFillPlanes;
 
         psCase = PSCase.HW;
         psId  += "1";
@@ -188,7 +188,7 @@ SampleSplitFrameAlpha("input.Texture.x", "0.5 + (input.Texture.y / 2)"), defines
         else
             ret = FLSWGrayConfig();
 
-        FillPlanes = scfg.VFlip ? FLSWFillPlanesFlip : FLSWFillPlanes;
+        fillPlanes = scfg.VFlip ? FLSWFillPlanesFlip : FLSWFillPlanes;
 
         for (int i = 0; i < scfg.PixelPlanes; i++)
             srvDesc[i].ViewDimension = ShaderResourceViewDimension.Texture2D;

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.FL.Sws.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.FL.Sws.cs
@@ -43,7 +43,7 @@ public unsafe partial class Renderer
             return false;
         }
 
-        FillPlanes  = VideoDecoder.VideoAccelerated ? SwsHWFillPlanes : SwsSWFillPlanes;
+        fillPlanes  = VideoDecoder.VideoAccelerated ? SwsHWFillPlanes : SwsSWFillPlanes;
         psCase      = PSCase.SwsScale;
 
         txtDesc[0].Width   = (uint)swsFrame->width;

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.cs
@@ -37,7 +37,20 @@ public unsafe partial class Renderer : IVP
     VPRequestType   vpRequestsIn, vpRequests; // In: From User | ProcessRequests Copy
 
     internal unsafe delegate VideoFrame FillPlanesDelegate(ref AVFrame* frame);
-    internal FillPlanesDelegate FillPlanes;
+    FillPlanesDelegate fillPlanes;
+
+    // Single choke point for every frame returned to consumers. Tracks the frame so a torn-down or
+    // source-switched renderer can deterministically dispose any frame that escaped the VideoCache
+    // (otherwise its native surface/SRV/VPIV is freed only by non-deterministic finalizers, pinning
+    // the D3D11 device and blocking driver memory reclamation).
+    internal unsafe VideoFrame FillPlanes(ref AVFrame* frame)
+    {
+        var mFrame = fillPlanes(ref frame);
+        if (mFrame != null)
+            TrackFrame(mFrame);
+
+        return mFrame;
+    }
 
     void IVP.VPRequest(VPRequestType request)
         => VPRequest(request);

--- a/FlyleafLib/MediaPlayer/Player.Open.cs
+++ b/FlyleafLib/MediaPlayer/Player.Open.cs
@@ -183,6 +183,15 @@ unsafe partial class Player
             if (CanInfo) Log.Info($"Opening {url_iostream}");
 
             Initialize(Status.Opening, false); // TBR: (false) Avoid initializing the decoder twice (might cause issues)
+
+            // Re-opening a source without a full Stop()/Renderer reset keeps the previous source's
+            // decoded frames alive (cache + frames that escaped it), so their D3D11 surfaces pile up
+            // across switches. Dispose them deterministically BEFORE the new decoder allocates, then
+            // Flush so D3D11 actually destroys them and the driver can reclaim the memory.
+            VideoDecoder?.DisposeFrames();
+            Renderer?.DisposeLiveFrames();
+            Renderer?.FlushContext();
+
             var args2 = decoder.Open(url_iostream, defaultPlaylistItem, defaultVideo, defaultAudio, defaultSubtitles);
 
             args.Url        = args2.Url;


### PR DESCRIPTION
## Summary

Re-opening a source on a `Player` (i.e. switching streams via `Open`/`OpenAsync`
without a full `Stop()`/renderer reset) leaks native GPU memory. The process's
**committed** memory grows on every switch and is only released when the device is
destroyed (Stop/dispose). On integrated Intel GPUs (where "VRAM" is system RAM) this
ratchets up until the machine runs out of commit charge.

## Root cause

A `VideoFrame` can leave the `VideoCache` and never be `Dispose()`d — e.g. the frame
held by the renderer/screamer at the moment of a source switch, seek, or hand-off.
`VideoFrame` has **no finalizer**, so the native objects it owns — the D3D11
`Texture`/`ShaderResourceView`/`VideoProcessorInputView` and the pinned `AVFrame` —
are released only when the COM wrappers are finalized by the GC.

Because the managed heap stays tiny during playback, Gen2 collections almost never
run, so those finalizers almost never run. Each switch therefore leaves the previous
source's frames (and their surfaces) committed while the new decoder allocates its
own → the concurrent peak is `old + new`, and committed memory never recovers.

A heap dump of a leaking process shows thousands of `VideoFrame` and
`ID3D11VideoProcessorInputView` instances that are **unrooted** (no GC root) but whose
native resources were never freed, while only a handful of `ID3D11Texture2D` remain
(HW frames share one texture array) — i.e. the managed wrappers are dead garbage and
the native memory leaked.

## Reproduction (current `master`)

1. Take any sample that drives a `Player` (e.g. the `FlyleafPlayer` sample).
2. Repeatedly switch the source on the **same** player without calling `Stop()`
   between switches — e.g. alternate `player.OpenAsync(A)` / `player.OpenAsync(B)`
   on a ~1s timer, or loop a playlist of a few items.
3. Watch the process's **Commit size** (Task Manager → add the "Commit size" column,
   or VMMap "Private Committed"). Do **not** rely on the Working Set — it is trimmed
   by the OS and hides the leak.
4. Committed memory rises by roughly one source's worth of surfaces per switch and
   never drops while the player keeps running.
   - Most visible with large **software-decoded** frames (e.g. big MJPEG/JPEG stills,
     several megapixels) and on Intel integrated GPUs; hardware-decoded streams leak
     more slowly but still ratchet up.
   - Calling `Stop()` (full renderer reset) before each `Open` releases the memory —
     confirming the leak is specific to the in-place re-open path.

## Fix

Track every frame the renderer hands out through the single `FillPlanes` choke point,
and dispose any survivors deterministically:
- in `Player.OpenInternal`, **before** the new decoder allocates (so the freed
  surfaces are reused instead of accumulating), and
- on renderer teardown (`DisposeLocal`).

A `Flush()` after disposal lets D3D11 actually destroy the released resources (there
is no `Present` on a paused/just-switched player to trigger deferred destruction).

### Changes
- `Renderer.Device.cs`: per-renderer live-frame registry (`TrackFrame`/`UntrackFrame`/
  `DisposeLiveFrames`) + `FlushContext()`; `DisposeLiveFrames()` is also called from
  `DisposeLocal`.
- `Renderer.VP.cs`: `FillPlanes` becomes a small wrapper around the (now private)
  `fillPlanes` delegate that records each returned frame.
- `VideoFrame`: gains an `Owner` back-reference and untracks itself on `Dispose()`.
- `Player.Open.cs`: dispose cached + escaped frames and flush before `decoder.Open(...)`.

No public API change (the affected members are `internal`). The per-frame tracking is
a `HashSet` add/remove guarded by a lock — negligible overhead on the frame path.

## Testing

Verified on an Intel integrated GPU (committed-memory growth is most pronounced there)
with a setup of several concurrent `Player`s, repeatedly switching one player's source
between an H.264 RTSP stream (hardware-decoded) and large multi-megapixel MJPEG stills
(software-decoded).

- **Committed memory** (Task Manager "Commit size" / VMMap "Private Committed", *not*
  Working Set): before the fix it rose by roughly one source's worth of surfaces on
  every switch and never recovered (~tens of MB per switch with the large SW frames,
  unbounded over ~30 switches). After the fix it stays bounded — it plateaus at roughly
  a single source's peak instead of ratcheting up.
- **Heap dump cross-check** (WinDbg + SOS): with the fix, `!dumpheap -stat -type
  VideoFrame` and `-type ID3D11VideoProcessorInputView` no longer show thousands of
  accumulating instances after repeated switches (they stay at a small steady count),
  and `!gcroot` on a sampled survivor confirms old frames are actually disposed rather
  than left as unrooted objects whose native resources were never released.
- **Both decode paths**: confirmed for the HW (D3D11 VideoProcessor) and SW frame
  paths; the regression was reproducible and is resolved on both.
- **No rendering/playback regression**: source switching, seeking and normal playback
  behave as before; no black frames or flicker introduced by the deterministic disposal
  + flush.