### PR TITLE
feat: Add 360° equirectangular video projection with mouse interaction and inertia

### DIFF
--- a/FlyleafLib/Controls/WPF/FlyleafHost.cs
+++ b/FlyleafLib/Controls/WPF/FlyleafHost.cs
@@ -120,6 +120,11 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
     double              curResizeRatio;
     bool                surfaceClosed, surfaceClosing, overlayClosed;
     double              panPrevX, panPrevY;
+    bool                isPano360Rotating;
+    POINT               pano360Prev;
+    double              pano360VelX, pano360VelY;
+    bool                pano360Inertia;
+    DateTimeOffset      pano360PrevTime;
     bool                isMouseBindingsSubscribedSurface;
     bool                isMouseBindingsSubscribedOverlay;
     Window              standAloneOverlay;
@@ -1141,6 +1146,22 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
             return; // No Capture
         }
 
+        // Pano360 Rotate (direct drag when 360 enabled)
+        else if (Player != null && Player.Config.Video.Pano360._enabled)
+        {
+            isPano360Rotating = true;
+            _ = GetCursorPos(out pMLD);
+            pano360Prev = pMLD;
+            pano360VelX = 0;
+            pano360VelY = 0;
+            pano360PrevTime = DateTimeOffset.Now;
+            if (pano360Inertia)
+            {
+                pano360Inertia = false;
+                CompositionTarget.Rendering -= Pano360Inertia_Tick;
+            }
+        }
+
         // PanMove
         else if (Player != null &&
             (PanMoveOnCtrl == availWindow || PanMoveOnCtrl == AvailableWindows.Both) &&
@@ -1190,10 +1211,23 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
     
     private void SO_ReleaseCapture(Window window)
     {
-        if (!IsResizing && !IsPanMoving && !IsDragMoving && !IsDragMovingOwner)
+        if (!IsResizing && !IsPanMoving && !IsDragMoving && !IsDragMovingOwner && !isPano360Rotating)
             return;
 
         window.ReleaseMouseCapture();
+
+        if (isPano360Rotating)
+        {
+            isPano360Rotating = false;
+
+            if (Math.Abs(pano360VelX) > 0.0001 || Math.Abs(pano360VelY) > 0.0001)
+            {
+                pano360Inertia = true;
+                pano360PrevTime = DateTimeOffset.Now;
+                CompositionTarget.Rendering += Pano360Inertia_Tick;
+            }
+            return;
+        }
 
         if (IsResizing)
         {
@@ -1227,6 +1261,39 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
             IsDragMovingOwner = false;
         else
             return;
+    }
+
+    const double friction = 0.965;
+    const double stopThreshold = 0.00005;
+
+    private void Pano360Inertia_Tick(object sender, EventArgs e)
+    {
+        if (!pano360Inertia || Player == null)
+        {
+            pano360Inertia = false;
+            CompositionTarget.Rendering -= Pano360Inertia_Tick;
+            return;
+        }
+
+        var now = DateTimeOffset.Now;
+        var dt = (now - pano360PrevTime).TotalMilliseconds;
+        pano360PrevTime = now;
+        if (dt <= 0) return;
+
+        var decay = Math.Pow(friction, dt / 16.0);
+        pano360VelX *= decay;
+        pano360VelY *= decay;
+
+        if (Math.Abs(pano360VelX) < stopThreshold && Math.Abs(pano360VelY) < stopThreshold)
+        {
+            pano360Inertia = false;
+            CompositionTarget.Rendering -= Pano360Inertia_Tick;
+            return;
+        }
+
+        var pano = Player.Config.Video.Pano360;
+        pano.RotationX += pano360VelX * (dt / 16.0);
+        pano.RotationY -= pano360VelY * (dt / 16.0);
     }
 
     private void Surface_MouseMove(object sender, MouseEventArgs e)
@@ -1284,6 +1351,29 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
         if (IsSwappingStarted)
             return;
 
+        // 360 Panoramic Rotation (direct drag)
+        if (isPano360Rotating)
+        {
+            var pano = Player.Config.Video.Pano360;
+            double dx = (cur.X - pano360Prev.X) / Surface.ActualWidth;
+            double dy = (cur.Y - pano360Prev.Y) / Surface.ActualHeight;
+
+            var now = DateTimeOffset.Now;
+            var dt = (now - pano360PrevTime).TotalMilliseconds;
+            if (dt > 0.01)
+            {
+                pano360VelX = dx / dt * 16.0;
+                pano360VelY = dy / dt * 16.0;
+            }
+
+            pano360Prev = cur;
+            pano360PrevTime = now;
+
+            pano.RotationX += dx;
+            pano.RotationY -= dy;
+            return;
+        }
+
         // Player's Pan Move (Ctrl + Drag Move)
         if (IsPanMoving)
         {
@@ -1337,6 +1427,17 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
         if (Player == null || e.Delta == 0 || e.Handled)
             return;
 
+        // 360 Panoramic Zoom (wheel without modifier)
+        if (Player.Config.Video.Pano360._enabled &&
+            !Keyboard.IsKeyDown(Key.LeftCtrl) && !Keyboard.IsKeyDown(Key.RightCtrl) &&
+            !Keyboard.IsKeyDown(Key.LeftShift) && !Keyboard.IsKeyDown(Key.RightShift))
+        {
+            var pano = Player.Config.Video.Pano360;
+            pano.Fov = pano.Fov + (e.Delta > 0 ? -5.0 : 5.0);
+            e.Handled = true;
+            return;
+        }
+
         if      ((Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl)) &&
             (PanZoomOnCtrlWheel == AvailableWindows.Surface || PanZoomOnCtrlWheel == AvailableWindows.Both))
         {
@@ -1369,6 +1470,16 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
     {
         if (Player == null || e.Delta == 0)
             return;
+
+        // 360 Panoramic Zoom (wheel without modifier)
+        if (Player.Config.Video.Pano360._enabled &&
+            !Keyboard.IsKeyDown(Key.LeftCtrl) && !Keyboard.IsKeyDown(Key.RightCtrl) &&
+            !Keyboard.IsKeyDown(Key.LeftShift) && !Keyboard.IsKeyDown(Key.RightShift))
+        {
+            var pano = Player.Config.Video.Pano360;
+            pano.Fov = pano.Fov + (e.Delta > 0 ? -5.0 : 5.0);
+            return;
+        }
 
         if      ((Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl)) &&
             (PanZoomOnCtrlWheel == AvailableWindows.Overlay || PanZoomOnCtrlWheel == AvailableWindows.Both))

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.FL.PS.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.FL.PS.cs
@@ -42,6 +42,12 @@ color = float4(
         psId    = "";
         defines = [];
 
+        if (ucfg.Pano360._enabled)
+        {
+            psId += "P";
+            defines.Add("dPano360");
+        }
+
         if (ucfg.hasFLFilters) // TODO: fix vp switch when set filters or unset*
         {
             psId += "-";

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.FL.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.FL.cs
@@ -30,6 +30,9 @@ public unsafe partial class Renderer
     ID3D11Buffer    vsBuffer;
     VSBufferType    vsData    = new();
 
+    ID3D11Buffer    panoBuffer;
+    PanoBufferType  panoData  = new() { PanoParams = new(0.5f, 0.5f, 0.5f, 90f), AspectRatio = 1.778f };
+
     bool            vflip;
 
     static InputElementDescription[] inputElements =
@@ -111,6 +114,7 @@ public unsafe partial class Renderer
     {
         vsBuffer        = device.CreateBuffer(vsDesc);
         psBuffer        = device.CreateBuffer(psDesc);
+        panoBuffer      = device.CreateBuffer(panoDesc);
         vertexBuffer    = device.CreateBuffer<float>(vertexBufferData, vertexBufferDesc);
         inputLayout     = device.CreateInputLayout(inputElements, ShaderCompiler.VSBlob);
         samplerLinear   = device.CreateSamplerState(samplerLinearDesc);
@@ -127,6 +131,7 @@ public unsafe partial class Renderer
         context.IASetInputLayout        (inputLayout);
         context.IASetPrimitiveTopology  (PrimitiveTopology.TriangleList);
         context.PSSetConstantBuffer     (0, psBuffer);
+        context.PSSetConstantBuffer     (1, panoBuffer);
         context.VSSetConstantBuffer     (0, vsBuffer);
         context.VSSetShader             (vsMain);
         context.PSSetSampler            (0, samplerLinear);
@@ -138,6 +143,10 @@ public unsafe partial class Renderer
     {
         SetViewport(ControlWidth, ControlHeight);
         context.RSSetViewport(Viewport);
+
+        // Update pano aspectRatio when viewport changes
+        if (ucfg.Pano360._enabled)
+            vpRequests |= VPRequestType.Pano360;
     }
     void FLSetRotationFlip()
     {
@@ -261,6 +270,9 @@ public unsafe partial class Renderer
             if (vpRequests.HasFlag(VPRequestType.HDRtoSDR))
                 FLSetHDRtoSDR();
 
+            if (vpRequests.HasFlag(VPRequestType.Pano360))
+                FLSetPano360();
+
             if (vpRequests.HasFlag(VPRequestType.UpdateVS))
                 context.UpdateSubresource(vsData, vsBuffer);
 
@@ -312,6 +324,7 @@ public unsafe partial class Renderer
         
         vsBuffer.       Dispose();
         psBuffer.       Dispose();
+        panoBuffer.     Dispose();
         inputLayout.    Dispose();
         vertexBuffer.   Dispose();
         samplerLinear.  Dispose();
@@ -373,5 +386,33 @@ public unsafe partial class Renderer
             Matrix  = Matrix4x4.Identity;
             Crop    = new(0, 0, 1, 1);
         }
+    }
+
+    static BufferDescription panoDesc = new()
+    {
+        Usage           = ResourceUsage.Default,
+        BindFlags       = BindFlags.ConstantBuffer,
+        CPUAccessFlags  = CpuAccessFlags.None,
+        ByteWidth       = (uint)(sizeof(PanoBufferType) + (16 - (sizeof(PanoBufferType) % 16)))
+    };
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct PanoBufferType
+    {
+        public Vector4 PanoParams;  // rotationX, rotationY, zoom, fov
+        public float AspectRatio;
+        float _pad1, _pad2, _pad3;  // 16-byte alignment
+    }
+
+    void FLSetPano360()
+    {
+        var pano = ucfg.Pano360;
+        panoData.PanoParams = new((float)pano._rotationX, (float)pano._rotationY,
+                                 (float)pano._zoom, (float)pano._fov);
+        // aspectRatio based on control (viewport) size, not video source size
+        panoData.AspectRatio = ControlWidth > 0 && ControlHeight > 0
+            ? (float)ControlWidth / ControlHeight : 1.778f;
+        context.UpdateSubresource(panoData, panoBuffer);
+        vpRequests &= ~VPRequestType.Pano360;
     }
 }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VP.cs
@@ -76,6 +76,10 @@ public unsafe partial class Renderer : IVP
         canFL = VideoDecoder.VideoAccelerated ||
             (!scfg.PixelFormatDesc->flags.HasFlag(PixFmtFlags.Pal) && (!scfg.PixelFormatDesc->flags.HasFlag(PixFmtFlags.Be) || scfg.PixelComp0Depth <= 8));
 
+        // 360 Panoramic mode requires Flyleaf VP (custom pixel shader)
+        if (ucfg.Pano360._enabled && canFL)
+            return VideoProcessors.Flyleaf;
+
         if (ucfg.VideoProcessor == VideoProcessors.D3D11    && canD3)
             return VideoProcessors.D3D11;
 
@@ -191,6 +195,9 @@ public unsafe partial class Renderer : IVP
     }
     void VPConfigHelper(bool request = true)
     {
+        if (scfg == null)
+            return;
+
         vpRequestsIn   &= ~VPRequestType.ReConfigVP;
         var oldVP       = VideoProcessor;
         var vpRequests  = VPRequestType.RotationFlip | VPRequestType.Crop | VPRequestType.UpdatePS; // TBR: we should set them all here as we don't compare with previous states
@@ -411,11 +418,21 @@ enum VPRequestType
     HDRtoSDR        = 1 << 8,   // Flyleaf
     UpdatePS        = 1 << 9,   // Flyleaf
     UpdateVS        = 1 << 10,  // Flyleaf
+    Pano360         = 1 << 11,  // Flyleaf - 360 Panoramic params update
 }
 
 public class VPConfig : NotifyPropertyChanged
 {
-    internal IVP vp;
+    internal IVP vp { get => _vp; set { _vp = value; Pano360.vp = value; } }
+    IVP _vp;
+
+    // === Pano 360 ===
+
+    /// <summary>
+    /// 360 Panoramic video projection settings
+    /// </summary>
+    [JsonIgnore]
+    public Pano360Config Pano360 { get; } = new();
 
     // === VP / Swap Chain ===
 
@@ -602,4 +619,51 @@ internal interface IVP
     void VPRequest(VPRequestType request);
     void UpdateSize(int width, int height);
     void MonitorChanged(GPUOutput monitor);
+}
+
+/// <summary>
+/// Configuration for 360 panoramic (equirectangular) video projection
+/// </summary>
+public class Pano360Config : NotifyPropertyChanged
+{
+    internal IVP vp;
+
+    /// <summary>
+    /// Enables 360 panoramic projection mode (forces Flyleaf VP)
+    /// </summary>
+    public bool Enabled { get => _enabled; set { if (Set(ref _enabled, value)) vp?.VPRequest(VPRequestType.ReConfigVP); } }
+    internal bool _enabled;
+
+    /// <summary>
+    /// Horizontal rotation [0.0, 1.0], 0.5 = front
+    /// </summary>
+    [JsonIgnore]
+    public double RotationX { get => _rotationX; set { if (Set(ref _rotationX, value)) vp?.VPRequest(VPRequestType.Pano360); } }
+    internal double _rotationX = 0.5;
+
+    /// <summary>
+    /// Vertical rotation [0.01, 0.99], 0.5 = horizon
+    /// </summary>
+    [JsonIgnore]
+    public double RotationY { get => _rotationY; set { if (Set(ref _rotationY, Math.Clamp(value, 0.01, 0.99))) vp?.VPRequest(VPRequestType.Pano360); } }
+    internal double _rotationY = 0.5;
+
+    /// <summary>
+    /// Zoom level [0.1, 2.0], default 0.5
+    /// </summary>
+    [JsonIgnore]
+    public double Zoom { get => _zoom; set { if (Set(ref _zoom, Math.Clamp(value, 0.1, 2.0))) vp?.VPRequest(VPRequestType.Pano360); } }
+    internal double _zoom = 0.5;
+
+    /// <summary>
+    /// Field of view in degrees [30, 150], default 90
+    /// </summary>
+    [JsonIgnore]
+    public double Fov { get => _fov; set { if (Set(ref _fov, Math.Clamp(value, 30.0, 150.0))) vp?.VPRequest(VPRequestType.Pano360); } }
+    internal double _fov = 90.0;
+
+    /// <summary>
+    /// Reset all pano parameters to defaults
+    /// </summary>
+    public void Reset() { RotationX = 0.5; RotationY = 0.5; Zoom = 0.5; Fov = 90.0; }
 }

--- a/FlyleafLib/MediaFramework/MediaRenderer/ShaderCompiler.PS.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/ShaderCompiler.PS.cs
@@ -50,6 +50,41 @@ cbuffer         Config          : register(b0)
 
 SamplerState    Sampler         : register(s0);
 
+#if defined(dPano360)
+cbuffer PanoConfig : register(b1)
+{
+    float4 panoParams;   // rotationX, rotationY, zoom, fov
+    float  aspectRatio;
+};
+
+#define PI_PANO 3.1415926535897932384626433832795
+#define DEG2RAD_PANO 0.01745329251994329576923690768489
+
+inline float3 PanoRotateXY(float3 p, float2 angle)
+{
+    float2 c = cos(angle);
+    float2 s = sin(angle);
+    p = float3(p.x, c.x * p.y + s.x * p.z, -s.x * p.y + c.x * p.z);
+    return float3(c.y * p.x + s.y * p.z, p.y, -s.y * p.x + c.y * p.z);
+}
+
+inline float2 PanoProject(float2 uv)
+{
+    float2 sampleUV = uv - 0.5;
+    float hfovRad = panoParams.w * DEG2RAD_PANO;
+    float vfovRad = 2.0 * atan(tan(hfovRad * 0.5) / aspectRatio);
+    float3 camDir = normalize(float3(
+        -sampleUV.x * tan(hfovRad * 0.5),
+         sampleUV.y * tan(vfovRad * 0.5),
+         panoParams.z));
+    float3 camRot = float3(
+        (panoParams.x - 0.5) * 2.0 * PI_PANO,
+        (panoParams.y - 0.5) * PI_PANO, 0.0);
+    float3 rd = normalize(PanoRotateXY(camDir, camRot.yx));
+    return float2(atan2(rd.z, rd.x) + PI_PANO, acos(-rd.y)) / float2(2.0 * PI_PANO, PI_PANO);
+}
+#endif
+
 inline float3 LinearToSRGB(float3 c)
 {
     float3 srgbLo = c * 12.92;
@@ -275,6 +310,9 @@ struct PSInput
 float4 main(PSInput input) : SV_TARGET
 {
     float4 color;
+#if defined(dPano360)
+    input.Texture = PanoProject(input.Texture);
+#endif
 "u8;
 
     static ReadOnlySpan<byte> PS_FOOTER => @"

--- a/Samples/FlyleafPlayer (Custom - MVVM) (WPF)/MainWindow.xaml
+++ b/Samples/FlyleafPlayer (Custom - MVVM) (WPF)/MainWindow.xaml
@@ -40,6 +40,22 @@
                 <!-- Show/Hide Player's Debug Information -->
                 <Button Content="Show/Hide Debug" Command="{Binding ToggleDebug}" Height="20" Width="110" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="-40"/>
 
+                <!-- 360 Panoramic Controls -->
+                <StackPanel VerticalAlignment="Top" HorizontalAlignment="Left" Margin="-40 0 0 0">
+                    <CheckBox Content="360 Panoramic" Foreground="Cyan" FontWeight="Bold"
+                              IsChecked="{Binding Player.Config.Video.Pano360.Enabled, Mode=TwoWay}"/>
+                    <StackPanel Orientation="Horizontal" Margin="0 4 0 0">
+                        <TextBlock Text="FOV:" Foreground="White" VerticalAlignment="Center"/>
+                        <Slider Width="100" Minimum="30" Maximum="150" 
+                                Value="{Binding Player.Config.Video.Pano360.Fov, Mode=TwoWay}" 
+                                VerticalAlignment="Center" Margin="4 0"/>
+                        <TextBlock Text="{Binding Player.Config.Video.Pano360.Fov, StringFormat={}{0:F0}°}" 
+                                   Foreground="White" VerticalAlignment="Center"/>
+                    </StackPanel>
+                    <Button Content="Reset View" Width="70" HorizontalAlignment="Left" Margin="0 4 0 0"
+                            Click="Pano360Reset_Click"/>
+                </StackPanel>
+
                 <fl:PlayerDebug VerticalAlignment="Center" HorizontalAlignment="Center"
                                Player="{Binding Player}"
                                BoxColor="#A0000000"

--- a/Samples/FlyleafPlayer (Custom - MVVM) (WPF)/MainWindow.xaml.cs
+++ b/Samples/FlyleafPlayer (Custom - MVVM) (WPF)/MainWindow.xaml.cs
@@ -87,5 +87,10 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         Player.Config.Video.Crop = crop;
     }
 
+    private void Pano360Reset_Click(object sender, RoutedEventArgs e)
+    {
+        Player?.Config.Video.Pano360.Reset();
+    }
+
     public event PropertyChangedEventHandler PropertyChanged;
 }

--- a/Samples/FlyleafPlayer (WPF Control) (WPF)/Dictionary.xaml
+++ b/Samples/FlyleafPlayer (WPF Control) (WPF)/Dictionary.xaml
@@ -162,6 +162,7 @@
             </MenuItem>
             <MenuItem Header="H. Flip" IsCheckable="True" IsChecked="{Binding Config.Video.HFlip}"/>
             <MenuItem Header="V. Flip" IsCheckable="True" IsChecked="{Binding Config.Video.VFlip}"/>
+            <MenuItem Header="360 Panoramic" IsCheckable="True" IsChecked="{Binding Config.Video.Pano360.Enabled}"/>
             <MenuItem Header="Reverse Playback" IsCheckable="True" IsChecked="{Binding Player.ReversePlayback}"/>
             <MenuItem Header="Loop Playback"    IsCheckable="True" IsChecked="{Binding Player.LoopPlayback}"/>
             <MenuItem Header="{Binding Player.Speed}" HeaderStringFormat="Speed (x{0})">


### PR DESCRIPTION
## 360° Panoramic Video Playback

Flyleaf now supports real-time 360° equirectangular video projection with interactive viewport control.

### Rendering

- Equirectangular-to-sphere projection implemented in the HLSL pixel shader (`FlyleafVP.hlsl`), activated via the `dPano360` preprocessor define.
- Projection parameters (rotation, FOV, aspect ratio) are passed to the GPU through a dedicated constant buffer (`cbPano360`, register `b1`).
- The shader remaps screen-space UV coordinates to spherical coordinates based on the current viewing direction and field of view.

### Configuration

All 360 settings are encapsulated in `Pano360Config` (under `Config.Video.Pano360`):

| Property | Description | Range |
|----------|-------------|-------|
| `Enabled` | Toggle 360 projection on/off | `bool` |
| `RotationX` | Horizontal viewing angle (yaw) | 0.0 – 1.0 (wraps) |
| `RotationY` | Vertical viewing angle (pitch) | -0.5 – 0.5 (clamped) |
| `Fov` | Field of view in degrees | 30 – 150 |

### Mouse Interaction (WPF FlyleafHost)

- **Drag rotation**: Left-click and drag to rotate the viewport. Horizontal drag maps to yaw, vertical drag maps to pitch.
- **Inertia**: On release, the current instantaneous velocity (computed per-frame in `MouseMove` as `displacement / dt`) is carried forward with frame-rate-independent exponential decay: `decay = Math.Pow(friction, dt / 16.0)`.
- **Scroll zoom**: Mouse wheel adjusts FOV by ±5° per notch (without Ctrl/Shift held).

### Enabling

- **Programmatically**: `player.Config.Video.Pano360.Enabled = true;`
- **WPF Control sample**: Right-click → Video → "360 Panoramic" (checkable menu item)
- **MVVM sample**: CheckBox + FOV slider + Reset button in the overlay panel