### PR TITLE
Fix two thread races in the frame-step paths (ShowFrameNext/Prev vs the Seek task; GetFrameNext vs the running demuxer)

### DIFF
--- a/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
+++ b/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
@@ -525,6 +525,10 @@ public unsafe partial class DecoderContext : PluginHandler
                 if (ret != 0)
                 {
                     av_packet_free(&packet);
+                    // [Local patch eofdrain] Demuxer EOF with the target still
+                    // ahead: the remaining frames (incl. the FINAL frame) sit
+                    // in the codec's delay pipeline — drain before giving up.
+                    DrainVideoFrame(timestamp);
                     return;
                 }
             }
@@ -623,6 +627,36 @@ public unsafe partial class DecoderContext : PluginHandler
         } // While
 
         return;
+    }
+
+    /* [Local patch eofdrain 3.10.4.3] GetVideoFrame's EOF tail: the demuxer is
+     * exhausted but the accurate-seek target lies within the codec's delay
+     * pipeline (always true for the stream's FINAL frame). Without this, an
+     * end-of-stream seek presented NOTHING while every readback claimed
+     * success. Mirrors the frame-step path's drain (VideoDecoder.
+     * DecodeFrameNext) with GetVideoFrame's own acceptance test. Caller
+     * already holds lockFmtCtx + lockCodecCtx. */
+    private void DrainVideoFrame(long timestamp)
+    {
+        if (VideoDecoder.SendDrainAVPacket() != 0)
+            return;
+
+        while (VideoDemuxer.VideoStream != null && !Interrupt)
+        {
+            if (VideoDecoder.RecvAVFrame() != 0)
+                return; // fully drained (EOF), needs input (EAGAIN) or critical
+
+            // Accurate seek with +- half frame distance (same test as above).
+            if (timestamp != -1 && !VideoDemuxer.IsLive && (long)(VideoDecoder.frame->pts * VideoStream.Timebase) - VideoDemuxer.StartTime + (VideoStream.FrameDuration / 2) < timestamp)
+            {
+                av_frame_unref(VideoDecoder.frame);
+                continue;
+            }
+
+            int ret = VideoDecoder.FillEnqueueAVFrame();
+            if (ret == 0 || ret == -1234)
+                return; // success or critical — done either way
+        }
     }
     public new void Dispose()
     {

--- a/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
+++ b/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
@@ -28,6 +28,25 @@ public unsafe partial class DecoderContext : PluginHandler
      */
 
     #region Properties
+    /// <summary>
+    /// [Local patch 2026-07-20, MultiAngleVideoPlayer stepfix] Serializes
+    /// stopped-state decode operations that touch the codec/format contexts
+    /// from DIFFERENT threads: the player's seek task (Seek + GetVideoFrame)
+    /// versus frame stepping (VideoDecoder.GetFrame/GetFrameNext via
+    /// Player.ShowFrame/ShowFrameNext/ShowFramePrev). The step functions take
+    /// no internal locks (see the VideoDecoder TBR header) and relied on
+    /// "locks at higher level" — but the seek task runs OUTSIDE
+    /// Player.lockActions, so a step's Flush/decode could run concurrently
+    /// with the seek task's avcodec_send_packet on the SAME AVCodecContext,
+    /// corrupting native state (0xC0000005 / 0xC0000374 / 0xC0000409 —
+    /// reproducible with 3-4 players rapid-stepping while seeks were still
+    /// in flight). This lock is always the OUTERMOST in both paths, so the
+    /// pre-existing (inverted) internal lock orders — DecoderContext.Seek
+    /// takes codecCtx→fmtCtx while GetVideoFrame takes fmtCtx→codecCtx —
+    /// are never composed across threads.
+    /// </summary>
+    public readonly object      StepSeekLock        = new();
+
     public object               Tag                 { get; set; } // Upper Layer Object (eg. Player, Downloader) - mainly for plugins to access it
     public bool                 EnableDecoding      { get; set; }
     public new bool             Interrupt

--- a/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
@@ -575,6 +575,19 @@ public unsafe class VideoDecoder : DecoderBase
 
         return AVERROR_EAGAIN;
     }
+    internal int SendDrainAVPacket()
+    {   /* [Local patch eofdrain 3.10.4.3] Enters codec draining (send_packet
+         * with null) so the delay-pipeline tail — including the stream's FINAL
+         * frame — becomes receivable. GetVideoFrame's accurate seek otherwise
+         * returns at demuxer EOF with those frames stuck in the codec, so an
+         * end-of-stream target presented NOTHING (while CurTime echoed the
+         * seek and SeekCompleted fired). The frame-step path already drains
+         * (DecodeFrameNext); this gives the seek path the same ability. The
+         * next Flush/Seek's avcodec_flush_buffers resets draining state.
+         * Bypasses SendAVPacket deliberately: its key-packet validation
+         * dereferences the packet, and a drain request has none. */
+        return avcodec_send_packet(codecCtx, null);
+    }
     internal int RecvAVFrame()
     {   /* Receives frame from the decoder (avcodec_receive_frame) | Should be used as tied to Run Loop (vPackets[] / Frames[])
          * - Key Frame Validation

--- a/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
@@ -1092,6 +1092,17 @@ public unsafe class VideoDecoder : DecoderBase
     /// <returns>The next VideoFrame</returns>
     public VideoFrame GetFrameNext()
     {
+        // [Local patch stepfix] ENFORCE the documented contract instead of
+        // trusting callers: after a seek, VideoDemuxer.Start() leaves the
+        // demuxer thread filling queues, and its RunInternal shares fmtCtx AND
+        // the demuxer's single packet field with GetNextPacket — concurrent
+        // av_read_frame on both corrupts native state (AV in av_read_frame,
+        // reproducible with 3-4 players forward-stepping right after seeks).
+        // GetFrame() already pauses both; GetFrameNext was the missing one
+        // (see the TBR header: "Missing locks (e.g. GetFrameNext)").
+        demuxer.Pause();
+        Pause();
+
         checkExtraFrames = true;
 
         if (DecodeFrameNext() == 0)

--- a/FlyleafLib/MediaPlayer/Player.Extra.cs
+++ b/FlyleafLib/MediaPlayer/Player.Extra.cs
@@ -96,6 +96,10 @@ unsafe partial class Player
         lock (lockActions)
         {
             Pause();
+            // [Local patch stepfix] Serialized against the seek task (see
+            // DecoderContext.StepSeekLock).
+            lock (decoder.StepSeekLock)
+            {
             dFrame = null;
             sFrame = null;
             Renderer.SubsDispose();
@@ -112,6 +116,7 @@ unsafe partial class Player
             Renderer.RenderRequest(vFrame);
             UpdateCurTime(vFrame.Timestamp);
             reversePlaybackResync = true;
+            }
         }
     }
 
@@ -133,6 +138,10 @@ unsafe partial class Player
                 UI(() => Status = status);
             }
 
+            // [Local patch stepfix] Serialized against the seek task (see
+            // DecoderContext.StepSeekLock).
+            lock (decoder.StepSeekLock)
+            {
             shouldFlushPrev = true;
             decoder.RequiresResync = true;
 
@@ -162,6 +171,7 @@ unsafe partial class Player
             Renderer.RenderRequest(vFrame);
             UpdateCurTime(vFrame.Timestamp);
             reversePlaybackResync = true;
+            }
         }
     }
     public void ShowFramePrev()
@@ -179,6 +189,10 @@ unsafe partial class Player
                 UI(() => Status = status);
             }
 
+            // [Local patch stepfix] Serialized against the seek task (see
+            // DecoderContext.StepSeekLock).
+            lock (decoder.StepSeekLock)
+            {
             shouldFlushNext = true;
             decoder.RequiresResync = true;
 
@@ -206,6 +220,7 @@ unsafe partial class Player
 
             Renderer.RenderRequest(vFrame);
             UpdateCurTime(vFrame.Timestamp);
+            }
         }
     }
 

--- a/FlyleafLib/MediaPlayer/Player.Playback.cs
+++ b/FlyleafLib/MediaPlayer/Player.Playback.cs
@@ -293,12 +293,20 @@ partial class Player
                     }
                     else
                     {
+                        // [Local patch stepfix] Serialized against the frame-step
+                        // paths (see DecoderContext.StepSeekLock). SeekCompleted
+                        // fires OUTSIDE the lock — a subscriber calling back into
+                        // a lockActions-taking API must not deadlock against a
+                        // step holding lockActions and waiting for this lock.
+                        int? seekCompletedMs = null;
+                        lock (decoder.StepSeekLock)
+                        {
                         decoder.PauseDecoders();
                         ret = decoder.Seek(seekData.accurate ? Math.Max(0, seekData.ms - 3000) : seekData.ms, seekData.forward, !seekData.accurate); // 3sec ffmpeg bug for seek accurate when fails to seek backwards (see videodecoder getframe)
                         if (ret < 0)
                         {
                             if (CanWarn) Log.Warn("Seek failed");
-                            SeekCompleted?.Invoke(this, -1);
+                            seekCompletedMs = -1;
                         }
                         else if (!ReversePlayback && CanPlay)
                         {
@@ -310,8 +318,11 @@ partial class Player
                             SubtitlesDemuxer.Start();
                             DataDemuxer.Start();
                             decoder.PauseOnQueueFull();
-                            SeekCompleted?.Invoke(this, seekData.ms);
+                            seekCompletedMs = seekData.ms;
                         }
+                        }
+                        if (seekCompletedMs is int completedMs)
+                            SeekCompleted?.Invoke(this, completedMs);
                     }
 
                     Thread.Sleep(20);


### PR DESCRIPTION
**What breaks:** with three or more `Player` instances open, frame-stepping (`ShowFrameNext`/`ShowFramePrev`) shortly after a seek crashes the process, typically within seconds. The crash is `0xC0000005` inside `avcodec_send_packet`, and it is reproducible on stock 3.10.4 essentially 100% of the time under that pattern. Two `Player` instances never reproduced it.

**Why:** two paths touch native FFmpeg state without a common lock. Both are already flagged in the library's own TBR comments.

1. **`Player.Seek`'s background task vs `ShowFrameNext`/`ShowFramePrev` on the same `AVCodecContext`.** The seek task runs `decoder.Seek` / `GetVideoFrame` *outside* `Player.lockActions`, while the step paths call `Flush`/decode on the same codec context. `DecoderContext.cs:510` records the gap: *"TBR: Between seek and GetVideoFrame lockCodecCtx is lost and if VideoDecoder is running will already have decoded some frames (Currently ensure you pause VideDecoder before seek)"*. The step paths do not pause the decoder, so the precondition is not met.

2. **`VideoDecoder.GetFrameNext` vs the running demuxer on the same `fmtCtx`.** Its own summary states the precondition — *"Gets next VideoFrame (Decoder/Demuxer must not be running)"* (`VideoDecoder.cs:1103`) — but it never enforces it, and the demuxer thread shares both `fmtCtx` and its single packet field with `GetNextPacket`. The file header names this directly: *"Missing locks (e.g. GetFrameNext) / Missing checks after locks (e.g. disposed) / Mixing locks (actions/demuxer/codecCtx/renderer)"* (`VideoDecoder.cs:13`).

**What the patch does:**

1. Adds `DecoderContext.StepSeekLock`, taken by both the seek task and the frame-step paths, so decoder work from a seek can no longer interleave with a step on the same codec context.
2. Makes `GetFrameNext` pause the demuxer and decoder before running, matching what `GetFrame` has always done and satisfying its own documented precondition.

**Why `StepSeekLock` is a new outermost lock rather than reusing the existing ones.** Composing the existing locks is not possible without deadlocking: upstream's lock acquisition orders are already inverted between the seek path and `GetVideoFrame`, so any attempt to nest `lockActions` and `lockCodecCtx` consistently across both deadlocks one side or the other. A separate outermost lock, acquired before either, is the smallest change that serialises the two paths without reordering existing acquisitions.

**Why `SeekCompleted` moved outside the lock.** Firing it while holding `StepSeekLock` deadlocks any subscriber that calls back into a `lockActions`-taking API — a frame step holding `lockActions` would be waiting on `StepSeekLock`, and the event handler would be waiting on `lockActions`. The event now fires after the lock is released; the completed-ms value is captured inside and raised outside.

**Verification.** With the patch, the full step/seek matrix at 3 and 4 concurrent `Player` instances runs clean, including sustained stress: repeated native steps in both directions, steps immediately following seeks, and interleaved seek bursts. Round-trip accuracy is unchanged — +30/-30 step round trips return to the exact tick with pixel-identical frames, and every tile rests on its frame grid after 60 native steps. Step latency is unchanged within measurement noise.

---

**Second commit — unrelated fix, `eofdrain`.** `GetVideoFrame` (the accurate-seek path) returned at demuxer EOF without draining the codec's delay pipeline, where the stream's final frame always sits. The effect is that an accurate seek to end-of-stream could never present the last frame: `CurTime` echoed the requested position and `SeekCompleted` fired with the requested ms, but nothing was shown. It now sends a drain packet and receives the tail under the same half-frame acceptance test the frame-step path already uses (`DecodeFrameNext`). A new `SendDrainAVPacket` is needed because `SendAVPacket(null)` null-derefs its key-packet check.

Verified by pixel comparison against frames extracted independently with `ffmpeg -ss <pos> -frames:v 1`: ~44-46 dB PSNR for a correct final frame, ~10 dB for a wrong one. Note that neither `CurTime` nor `SeekCompleted` is trustworthy evidence on this path — both report success for a seek that presented nothing — so the fix was validated on pixels rather than on engine-reported state.

---

Happy to split the two commits into separate PRs if that is easier to review, or to adjust the locking approach if there is a composition you would prefer.
