### PR TITLE
Fix seeking in videos that doesn't have frame key flag

### DIFF
--- a/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
@@ -616,7 +616,7 @@ public unsafe class VideoDecoder : DecoderBase
 
         if (keyFrameRequired)
         {
-            if (!frame->flags.HasFlag(FrameFlags.Key))
+            if (!frame->flags.HasFlag(FrameFlags.Key) && frame->pict_type != AVPictureType.I)
             {
                 if (CanInfo) Log.Info("Ignoring non-key frame");
                 av_frame_unref(frame);
@@ -1198,7 +1198,7 @@ public unsafe class VideoDecoder : DecoderBase
 
         if (keyFrameRequired)
         {
-            if (!frame->flags.HasFlag(FrameFlags.Key)) { av_frame_unref(frame); DecodeFrameNextInternal(); }
+            if (!frame->flags.HasFlag(FrameFlags.Key) && frame->pict_type != AVPictureType.I) { av_frame_unref(frame); DecodeFrameNextInternal(); }
             keyFrameRequired = false;
         }
 


### PR DESCRIPTION
Some videos does not have the Key flag on frames.
If that is the case, we will keep seeking until end of file and playback will stop. Instead we can also check if the frame is an I-frame which solves this problem.